### PR TITLE
fix: use c_char in AMD GPU FFI for aarch64 compat

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.5.1",
-  "created_at": "2026-02-26T15:24:30.110764276Z",
+  "created_at": "2026-02-26T15:46:55.612835990Z",
   "git_context": null,
   "files": {},
   "summary": {

--- a/src/monitor/collectors/gpu_amd.rs
+++ b/src/monitor/collectors/gpu_amd.rs
@@ -21,6 +21,7 @@ use crate::monitor::error::{MonitorError, Result};
 use crate::monitor::ring_buffer::RingBuffer;
 use crate::monitor::types::{Collector, MetricValue, Metrics};
 use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
 use std::time::Duration;
 
 /// ROCm SMI status codes
@@ -93,7 +94,7 @@ struct RocmSmi {
     rsmi_init: unsafe extern "C" fn(u64) -> i32,
     rsmi_shut_down: unsafe extern "C" fn() -> i32,
     rsmi_num_monitor_devices: unsafe extern "C" fn(*mut u32) -> i32,
-    rsmi_dev_name_get: unsafe extern "C" fn(u32, *mut i8, usize) -> i32,
+    rsmi_dev_name_get: unsafe extern "C" fn(u32, *mut c_char, usize) -> i32,
     rsmi_dev_busy_percent_get: unsafe extern "C" fn(u32, *mut u32) -> i32,
     rsmi_dev_memory_busy_percent_get: unsafe extern "C" fn(u32, *mut u32) -> i32,
     rsmi_dev_memory_total_get: unsafe extern "C" fn(u32, u32, *mut u64) -> i32,
@@ -197,7 +198,7 @@ impl RocmSmi {
     }
 
     fn device_name(&self, index: u32) -> String {
-        let mut name_buf = [0i8; 256];
+        let mut name_buf = [0 as c_char; 256];
         // SAFETY: rsmi_dev_name_get writes at most 256 bytes into name_buf.
         // CStr::from_ptr is safe because the buffer is null-terminated by ROCm SMI.
         unsafe {


### PR DESCRIPTION
## Summary
- Replace hardcoded `i8` with `c_char` in ROCm SMI FFI type and name buffer
- `c_char` is `u8` on aarch64 but `i8` on x86_64 — blocks cross-compilation
- Same pattern as trueno-gpu#151

## Test plan
- [x] `cargo check` passes on x86_64
- [ ] Cross-compile for `aarch64-unknown-linux-gnu` succeeds

Refs PMAT-035

🤖 Generated with [Claude Code](https://claude.com/claude-code)