### PR TITLE
ci: fix unified gate workflow reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   unified:
-    uses: paiml/infra/.github/workflows/unified-gate.yml@main
+    uses: paiml/.github/.github/workflows/unified-gate.yml@main
     with:
       repo: ${{ github.event.repository.name }}
       pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
   # ── Gate: unified CI must pass before publish ──────────
   gate:
     needs: create-release
-    uses: paiml/infra/.github/workflows/unified-gate.yml@main
+    uses: paiml/.github/.github/workflows/unified-gate.yml@main
     with:
       repo: ${{ github.event.repository.name }}
       pr_sha: ${{ github.sha }}


### PR DESCRIPTION
Fix reusable workflow ref: paiml/infra → paiml/.github (public repos cannot call private repo workflows).

Generated with [Claude Code](https://claude.com/claude-code)