### PR TITLE
chore: bump ttop to v0.3.5

### DIFF
--- a/crates/ttop/Cargo.lock
+++ b/crates/ttop/Cargo.lock
@@ -3500,7 +3500,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttop"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "batuta-common",

--- a/crates/ttop/Cargo.toml
+++ b/crates/ttop/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ttop"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 rust-version = "1.75"
 authors = ["PAIML Team"]


### PR DESCRIPTION
## Summary
- Version bump to v0.3.5 after crates.io publish of the zombie process fix (#14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)