### PR TITLE
ci: migrate to self-hosted runners (§2.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI — lint, test, coverage, security, and unified gate
+# CI — self-hosted clean-room runners for sovereignty (§2.1.1)
 name: CI
 
 on:
@@ -15,10 +15,7 @@ concurrency:
 jobs:
   gate:
     name: Quality Gate
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable]
+    runs-on: [self-hosted, clean-room]
     steps:
       - uses: actions/checkout@v4
 

--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,8 +1,4546 @@
 {
   "version": "3.7.1",
-  "created_at": "2026-03-21T14:45:42.101968538Z",
+  "created_at": "2026-03-21T21:09:08.581152924Z",
   "git_context": null,
   "files": {
+    "./src/monitor/collectors/gpu_nvidia.rs": {
+      "content_hash": [
+        81,
+        56,
+        61,
+        223,
+        40,
+        210,
+        69,
+        0,
+        178,
+        121,
+        146,
+        56,
+        145,
+        177,
+        175,
+        247,
+        247,
+        77,
+        6,
+        93,
+        133,
+        181,
+        16,
+        15,
+        133,
+        20,
+        156,
+        238,
+        147,
+        114,
+        175,
+        77
+      ],
+      "score": {
+        "structural_complexity": 22.9,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.545456,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/gpu_nvidia.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.1000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 22"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/monitor_unit_tests.rs": {
+      "content_hash": [
+        210,
+        24,
+        53,
+        155,
+        109,
+        103,
+        195,
+        7,
+        250,
+        151,
+        123,
+        57,
+        110,
+        24,
+        30,
+        65,
+        188,
+        82,
+        238,
+        252,
+        66,
+        213,
+        214,
+        51,
+        13,
+        127,
+        208,
+        123,
+        177,
+        227,
+        153,
+        186
+      ],
+      "score": {
+        "structural_complexity": 22.6,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.075354,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 98.675354,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/monitor_unit_tests.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.4,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 23"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.9246466,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 19.6%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 49 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/heatmap_correlation.rs": {
+      "content_hash": [
+        64,
+        203,
+        186,
+        244,
+        190,
+        136,
+        238,
+        253,
+        137,
+        159,
+        170,
+        125,
+        155,
+        130,
+        39,
+        196,
+        238,
+        181,
+        28,
+        124,
+        176,
+        28,
+        77,
+        16,
+        115,
+        50,
+        25,
+        37,
+        228,
+        44,
+        117,
+        211
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/heatmap_correlation.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/interop/mod.rs": {
+      "content_hash": [
+        169,
+        92,
+        28,
+        107,
+        102,
+        225,
+        195,
+        169,
+        93,
+        113,
+        222,
+        146,
+        183,
+        200,
+        33,
+        134,
+        7,
+        140,
+        76,
+        249,
+        244,
+        192,
+        168,
+        98,
+        139,
+        119,
+        10,
+        79,
+        174,
+        234,
+        39,
+        216
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.555555,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 95.05051,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/interop/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.4444447,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 22.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/color.rs": {
+      "content_hash": [
+        34,
+        96,
+        13,
+        235,
+        215,
+        223,
+        153,
+        255,
+        167,
+        232,
+        202,
+        199,
+        77,
+        102,
+        242,
+        0,
+        89,
+        59,
+        196,
+        57,
+        6,
+        26,
+        217,
+        29,
+        46,
+        252,
+        132,
+        65,
+        63,
+        175,
+        56,
+        190
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.0,
+        "total": 97.27273,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/color.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 6 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/stack.rs": {
+      "content_hash": [
+        201,
+        195,
+        248,
+        198,
+        247,
+        68,
+        120,
+        115,
+        80,
+        101,
+        210,
+        2,
+        53,
+        252,
+        12,
+        124,
+        121,
+        234,
+        40,
+        56,
+        237,
+        110,
+        246,
+        216,
+        220,
+        81,
+        253,
+        59,
+        42,
+        133,
+        235,
+        0
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/stack.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/presets.rs": {
+      "content_hash": [
+        52,
+        3,
+        64,
+        203,
+        152,
+        221,
+        24,
+        244,
+        205,
+        83,
+        252,
+        123,
+        251,
+        222,
+        25,
+        177,
+        109,
+        49,
+        2,
+        146,
+        61,
+        64,
+        134,
+        193,
+        163,
+        124,
+        191,
+        244,
+        162,
+        92,
+        56,
+        196
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.446701,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.22427,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/presets.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5532997,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.8%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 14 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/theme-tomorrow_night.js": {
+      "content_hash": [
+        118,
+        179,
+        26,
+        36,
+        133,
+        52,
+        192,
+        172,
+        173,
+        242,
+        169,
+        253,
+        35,
+        120,
+        188,
+        122,
+        83,
+        111,
+        108,
+        254,
+        244,
+        57,
+        208,
+        171,
+        110,
+        22,
+        145,
+        132,
+        207,
+        209,
+        136,
+        24
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/theme-tomorrow_night.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/theme-dawn.js": {
+      "content_hash": [
+        224,
+        153,
+        56,
+        154,
+        73,
+        73,
+        47,
+        60,
+        173,
+        253,
+        234,
+        226,
+        58,
+        250,
+        84,
+        2,
+        147,
+        47,
+        105,
+        0,
+        79,
+        181,
+        190,
+        177,
+        155,
+        154,
+        230,
+        28,
+        8,
+        4,
+        145,
+        82
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/theme-dawn.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/gpu_procs.rs": {
+      "content_hash": [
+        80,
+        25,
+        181,
+        248,
+        109,
+        35,
+        243,
+        239,
+        82,
+        174,
+        248,
+        136,
+        59,
+        117,
+        87,
+        135,
+        32,
+        143,
+        64,
+        154,
+        159,
+        12,
+        85,
+        199,
+        52,
+        106,
+        118,
+        25,
+        106,
+        230,
+        146,
+        94
+      ],
+      "score": {
+        "structural_complexity": 24.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.181816,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/gpu_procs.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 16"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 14 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/btop.rs": {
+      "content_hash": [
+        185,
+        228,
+        204,
+        79,
+        140,
+        96,
+        176,
+        198,
+        57,
+        47,
+        142,
+        195,
+        71,
+        38,
+        145,
+        35,
+        122,
+        249,
+        255,
+        149,
+        113,
+        73,
+        133,
+        88,
+        196,
+        26,
+        8,
+        169,
+        135,
+        60,
+        47,
+        56
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.890995,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 77.89099,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/btop.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 135"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.1090047,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.5%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 125"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 53 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/e2e/demo.spec.ts": {
+      "content_hash": [
+        56,
+        15,
+        3,
+        12,
+        183,
+        5,
+        7,
+        8,
+        247,
+        222,
+        124,
+        84,
+        93,
+        22,
+        227,
+        101,
+        16,
+        236,
+        11,
+        236,
+        226,
+        4,
+        223,
+        192,
+        51,
+        51,
+        222,
+        173,
+        41,
+        176,
+        112,
+        148
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.200001,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.090904,
+        "grade": "A",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./wasm-pkg/e2e/demo.spec.ts",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.7999997,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 24.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 24 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/graph.rs": {
+      "content_hash": [
+        254,
+        115,
+        146,
+        229,
+        191,
+        168,
+        88,
+        182,
+        173,
+        200,
+        229,
+        54,
+        160,
+        184,
+        31,
+        59,
+        140,
+        54,
+        135,
+        71,
+        141,
+        202,
+        29,
+        146,
+        133,
+        60,
+        124,
+        163,
+        118,
+        124,
+        238,
+        69
+      ],
+      "score": {
+        "structural_complexity": 12.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.714286,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 87.71429,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/graph.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.285714,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 21.4%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 34"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 65"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 38 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/bin/trueno_agent.rs": {
+      "content_hash": [
+        131,
+        179,
+        114,
+        144,
+        254,
+        3,
+        0,
+        45,
+        94,
+        65,
+        77,
+        239,
+        205,
+        44,
+        186,
+        133,
+        114,
+        58,
+        11,
+        83,
+        159,
+        191,
+        159,
+        80,
+        42,
+        148,
+        211,
+        213,
+        95,
+        18,
+        140,
+        248
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/bin/trueno_agent.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/renacer_hang_tests.rs": {
+      "content_hash": [
+        150,
+        209,
+        136,
+        128,
+        175,
+        134,
+        3,
+        54,
+        70,
+        205,
+        249,
+        42,
+        235,
+        79,
+        206,
+        40,
+        223,
+        61,
+        239,
+        239,
+        26,
+        227,
+        39,
+        15,
+        188,
+        80,
+        254,
+        247,
+        111,
+        11,
+        132,
+        102
+      ],
+      "score": {
+        "structural_complexity": 24.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.637169,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.851974,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/renacer_hang_tests.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 49 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 17"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.3628318,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.8%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/widgets/experiment/resource_bar.rs": {
+      "content_hash": [
+        173,
+        209,
+        89,
+        152,
+        247,
+        236,
+        10,
+        9,
+        215,
+        14,
+        136,
+        193,
+        222,
+        178,
+        50,
+        127,
+        108,
+        120,
+        62,
+        66,
+        32,
+        121,
+        44,
+        129,
+        117,
+        8,
+        69,
+        34,
+        10,
+        60,
+        232,
+        91
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/widgets/experiment/resource_bar.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/data.rs": {
+      "content_hash": [
+        178,
+        206,
+        217,
+        49,
+        66,
+        223,
+        147,
+        29,
+        21,
+        204,
+        64,
+        143,
+        220,
+        126,
+        14,
+        10,
+        250,
+        239,
+        195,
+        51,
+        247,
+        22,
+        102,
+        185,
+        92,
+        11,
+        75,
+        49,
+        250,
+        48,
+        22,
+        132
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.934273,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.57661,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/data.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0657277,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.3%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 17 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/pkg/trueno_viz_wasm.js": {
+      "content_hash": [
+        102,
+        65,
+        31,
+        248,
+        158,
+        145,
+        207,
+        197,
+        25,
+        187,
+        53,
+        119,
+        244,
+        81,
+        178,
+        179,
+        161,
+        231,
+        101,
+        16,
+        3,
+        84,
+        33,
+        122,
+        107,
+        118,
+        232,
+        73,
+        141,
+        146,
+        188,
+        158
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.867257,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.867256,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 80 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.132743,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 25.7%"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/panels/cpu.rs": {
+      "content_hash": [
+        98,
+        163,
+        147,
+        163,
+        137,
+        189,
+        231,
+        167,
+        142,
+        43,
+        92,
+        59,
+        209,
+        193,
+        152,
+        161,
+        171,
+        155,
+        96,
+        227,
+        34,
+        53,
+        215,
+        185,
+        173,
+        52,
+        207,
+        175,
+        202,
+        121,
+        210,
+        253
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 98.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/panels/cpu.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/cpu.rs": {
+      "content_hash": [
+        10,
+        42,
+        187,
+        85,
+        27,
+        31,
+        99,
+        0,
+        168,
+        73,
+        92,
+        215,
+        116,
+        40,
+        129,
+        90,
+        223,
+        20,
+        247,
+        241,
+        236,
+        50,
+        54,
+        19,
+        222,
+        38,
+        81,
+        98,
+        130,
+        219,
+        25,
+        31
+      ],
+      "score": {
+        "structural_complexity": 12.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.09602,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 89.09602,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/cpu.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 62"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 7 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.9039812,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.5%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 77 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/mod.rs": {
+      "content_hash": [
+        213,
+        116,
+        151,
+        0,
+        112,
+        211,
+        123,
+        28,
+        206,
+        20,
+        145,
+        46,
+        99,
+        227,
+        247,
+        110,
+        95,
+        209,
+        38,
+        14,
+        83,
+        106,
+        205,
+        28,
+        191,
+        200,
+        185,
+        143,
+        9,
+        176,
+        203,
+        41
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/subprocess.rs": {
+      "content_hash": [
+        234,
+        132,
+        7,
+        193,
+        60,
+        7,
+        156,
+        159,
+        149,
+        96,
+        235,
+        68,
+        123,
+        15,
+        239,
+        36,
+        125,
+        34,
+        8,
+        245,
+        230,
+        65,
+        44,
+        113,
+        194,
+        65,
+        122,
+        219,
+        47,
+        206,
+        175,
+        218
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/subprocess.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/coord.rs": {
+      "content_hash": [
+        146,
+        6,
+        109,
+        223,
+        241,
+        17,
+        89,
+        199,
+        41,
+        25,
+        55,
+        183,
+        101,
+        107,
+        21,
+        6,
+        241,
+        253,
+        135,
+        159,
+        61,
+        141,
+        162,
+        73,
+        26,
+        31,
+        112,
+        73,
+        29,
+        167,
+        59,
+        38
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/coord.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 14 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/network_stats.rs": {
+      "content_hash": [
+        153,
+        254,
+        244,
+        1,
+        24,
+        175,
+        149,
+        22,
+        252,
+        50,
+        174,
+        207,
+        71,
+        236,
+        44,
+        59,
+        127,
+        238,
+        165,
+        73,
+        42,
+        197,
+        250,
+        95,
+        100,
+        105,
+        55,
+        252,
+        225,
+        93,
+        20,
+        127
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.834394,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 77.8344,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/network_stats.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 107"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 68"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 41 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.165605,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.8%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/psi.rs": {
+      "content_hash": [
+        21,
+        14,
+        166,
+        47,
+        70,
+        36,
+        112,
+        251,
+        154,
+        210,
+        48,
+        164,
+        168,
+        127,
+        84,
+        130,
+        115,
+        213,
+        137,
+        178,
+        132,
+        239,
+        23,
+        45,
+        89,
+        189,
+        51,
+        62,
+        93,
+        171,
+        69,
+        246
+      ],
+      "score": {
+        "structural_complexity": 21.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 94.63636,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/psi.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.9,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 28"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/app.rs": {
+      "content_hash": [
+        113,
+        82,
+        171,
+        228,
+        224,
+        210,
+        146,
+        78,
+        127,
+        219,
+        162,
+        173,
+        164,
+        59,
+        253,
+        140,
+        231,
+        131,
+        125,
+        239,
+        131,
+        107,
+        45,
+        62,
+        1,
+        143,
+        178,
+        221,
+        41,
+        7,
+        168,
+        95
+      ],
+      "score": {
+        "structural_complexity": 23.8,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.36364,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/app.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.2,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 19"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/panel_evidence_test.rs": {
+      "content_hash": [
+        241,
+        71,
+        219,
+        92,
+        51,
+        44,
+        252,
+        195,
+        242,
+        79,
+        79,
+        230,
+        155,
+        68,
+        187,
+        85,
+        199,
+        120,
+        129,
+        180,
+        80,
+        224,
+        201,
+        210,
+        208,
+        25,
+        187,
+        176,
+        110,
+        166,
+        157,
+        71
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/panel_evidence_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/boxplot.rs": {
+      "content_hash": [
+        212,
+        32,
+        217,
+        51,
+        245,
+        72,
+        190,
+        13,
+        158,
+        104,
+        55,
+        50,
+        81,
+        211,
+        99,
+        90,
+        224,
+        42,
+        171,
+        56,
+        246,
+        162,
+        123,
+        168,
+        224,
+        109,
+        121,
+        41,
+        98,
+        111,
+        222,
+        155
+      ],
+      "score": {
+        "structural_complexity": 2.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.32353,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 78.82353,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/boxplot.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 87 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.6764705,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 18.4%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 110"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 12.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 55"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/lib.rs": {
+      "content_hash": [
+        225,
+        164,
+        167,
+        124,
+        61,
+        184,
+        55,
+        237,
+        63,
+        236,
+        37,
+        244,
+        16,
+        75,
+        161,
+        24,
+        43,
+        102,
+        23,
+        69,
+        226,
+        153,
+        39,
+        86,
+        240,
+        191,
+        201,
+        197,
+        205,
+        253,
+        253,
+        125
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/lib.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/state.rs": {
+      "content_hash": [
+        232,
+        246,
+        37,
+        56,
+        250,
+        155,
+        49,
+        70,
+        188,
+        160,
+        131,
+        55,
+        141,
+        175,
+        207,
+        71,
+        121,
+        9,
+        30,
+        215,
+        95,
+        175,
+        72,
+        236,
+        237,
+        117,
+        243,
+        57,
+        221,
+        47,
+        93,
+        143
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.5,
+        "total": 96.81818,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/state.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/output/html.rs": {
+      "content_hash": [
+        198,
+        20,
+        13,
+        188,
+        174,
+        248,
+        68,
+        186,
+        246,
+        213,
+        55,
+        72,
+        17,
+        25,
+        171,
+        153,
+        239,
+        190,
+        39,
+        190,
+        202,
+        185,
+        57,
+        23,
+        4,
+        251,
+        160,
+        206,
+        106,
+        246,
+        208,
+        12
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/output/html.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/heatmap.rs": {
+      "content_hash": [
+        49,
+        240,
+        61,
+        16,
+        24,
+        238,
+        183,
+        189,
+        116,
+        149,
+        144,
+        152,
+        185,
+        235,
+        46,
+        230,
+        29,
+        47,
+        78,
+        145,
+        151,
+        179,
+        189,
+        106,
+        151,
+        189,
+        23,
+        8,
+        96,
+        181,
+        228,
+        96
+      ],
+      "score": {
+        "structural_complexity": 24.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.862745,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.78432,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/heatmap.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.90000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 18"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.137255,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 22 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/scatter.rs": {
+      "content_hash": [
+        146,
+        143,
+        71,
+        199,
+        88,
+        162,
+        141,
+        136,
+        241,
+        5,
+        244,
+        226,
+        158,
+        186,
+        210,
+        140,
+        238,
+        51,
+        77,
+        180,
+        205,
+        204,
+        134,
+        99,
+        40,
+        225,
+        65,
+        145,
+        9,
+        202,
+        250,
+        63
+      ],
+      "score": {
+        "structural_complexity": 23.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.756098,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.96009,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/scatter.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.2439024,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.2%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 14 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 17"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/swap.rs": {
+      "content_hash": [
+        70,
+        8,
+        239,
+        160,
+        103,
+        76,
+        27,
+        104,
+        16,
+        34,
+        68,
+        35,
+        199,
+        24,
+        127,
+        197,
+        18,
+        131,
+        17,
+        83,
+        86,
+        128,
+        105,
+        57,
+        142,
+        10,
+        94,
+        131,
+        8,
+        124,
+        211,
+        141
+      ],
+      "score": {
+        "structural_complexity": 3.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 83.5,
+        "grade": "BPlus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/swap.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 60"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 11.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 53"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/panels/files.rs": {
+      "content_hash": [
+        169,
+        79,
+        205,
+        67,
+        147,
+        11,
+        221,
+        132,
+        106,
+        56,
+        161,
+        191,
+        113,
+        207,
+        10,
+        74,
+        229,
+        191,
+        235,
+        2,
+        240,
+        171,
+        179,
+        194,
+        72,
+        183,
+        33,
+        100,
+        52,
+        26,
+        237,
+        207
+      ],
+      "score": {
+        "structural_complexity": 24.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.90909,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/panels/files.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 17"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/network.rs": {
+      "content_hash": [
+        121,
+        121,
+        40,
+        8,
+        166,
+        161,
+        113,
+        1,
+        221,
+        85,
+        229,
+        85,
+        242,
+        139,
+        108,
+        108,
+        43,
+        12,
+        143,
+        241,
+        27,
+        87,
+        224,
+        17,
+        254,
+        33,
+        33,
+        48,
+        96,
+        254,
+        207,
+        183
+      ],
+      "score": {
+        "structural_complexity": 19.9,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.764471,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 97.664474,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/network.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.235529,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 37 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.1000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 32"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/interop/aprender.rs": {
+      "content_hash": [
+        184,
+        84,
+        61,
+        136,
+        54,
+        26,
+        66,
+        33,
+        186,
+        222,
+        47,
+        223,
+        97,
+        15,
+        166,
+        183,
+        76,
+        39,
+        202,
+        122,
+        139,
+        35,
+        67,
+        89,
+        28,
+        183,
+        29,
+        37,
+        87,
+        184,
+        85,
+        60
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.32558,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.11417,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/interop/aprender.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.6744187,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 18.4%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 47 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/clipboard.min.js": {
+      "content_hash": [
+        228,
+        7,
+        26,
+        156,
+        206,
+        210,
+        124,
+        20,
+        145,
+        231,
+        75,
+        54,
+        179,
+        199,
+        238,
+        114,
+        182,
+        2,
+        69,
+        99,
+        55,
+        208,
+        1,
+        97,
+        222,
+        234,
+        77,
+        56,
+        211,
+        11,
+        209,
+        88
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/clipboard.min.js",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/encoder_benchmark.rs": {
+      "content_hash": [
+        161,
+        138,
+        132,
+        199,
+        31,
+        3,
+        6,
+        250,
+        118,
+        56,
+        33,
+        187,
+        175,
+        26,
+        243,
+        99,
+        228,
+        57,
+        53,
+        92,
+        199,
+        96,
+        104,
+        79,
+        168,
+        102,
+        6,
+        152,
+        14,
+        193,
+        30,
+        26
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.818182,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.56198,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/encoder_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 15 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.181818,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.9%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/heatmap.rs": {
+      "content_hash": [
+        246,
+        62,
+        107,
+        189,
+        50,
+        182,
+        195,
+        167,
+        93,
+        0,
+        37,
+        208,
+        223,
+        18,
+        15,
+        119,
+        125,
+        190,
+        251,
+        127,
+        37,
+        233,
+        73,
+        27,
+        221,
+        179,
+        235,
+        135,
+        160,
+        113,
+        204,
+        106
+      ],
+      "score": {
+        "structural_complexity": 23.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.818184,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/heatmap.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.8000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 21"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 18 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/text_prompt.rs": {
+      "content_hash": [
+        120,
+        30,
+        94,
+        202,
+        170,
+        20,
+        74,
+        247,
+        73,
+        131,
+        81,
+        162,
+        86,
+        176,
+        105,
+        214,
+        120,
+        171,
+        189,
+        58,
+        142,
+        53,
+        182,
+        3,
+        31,
+        40,
+        164,
+        196,
+        103,
+        74,
+        228,
+        201
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.585365,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 94.62306,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/text_prompt.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.4146342,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.1%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/readme_demo.rs": {
+      "content_hash": [
+        107,
+        214,
+        188,
+        121,
+        144,
+        19,
+        65,
+        108,
+        67,
+        221,
+        132,
+        234,
+        143,
+        156,
+        167,
+        150,
+        33,
+        111,
+        86,
+        107,
+        31,
+        11,
+        81,
+        50,
+        219,
+        53,
+        24,
+        30,
+        70,
+        92,
+        83,
+        73
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/readme_demo.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/widgets/mod.rs": {
+      "content_hash": [
+        10,
+        35,
+        158,
+        18,
+        144,
+        226,
+        177,
+        150,
+        164,
+        223,
+        72,
+        28,
+        212,
+        99,
+        231,
+        241,
+        106,
+        153,
+        178,
+        136,
+        208,
+        40,
+        86,
+        231,
+        73,
+        176,
+        57,
+        26,
+        232,
+        160,
+        92,
+        219
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/widgets/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./pkg/trueno_viz.js": {
+      "content_hash": [
+        185,
+        14,
+        172,
+        161,
+        20,
+        78,
+        227,
+        232,
+        243,
+        189,
+        111,
+        175,
+        242,
+        70,
+        139,
+        48,
+        219,
+        25,
+        224,
+        168,
+        97,
+        24,
+        174,
+        118,
+        179,
+        113,
+        183,
+        21,
+        114,
+        216,
+        167,
+        232
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.160745,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.05522,
+        "grade": "A",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./pkg/trueno_viz.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 54 duplicate code patterns"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 5.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent quote usage detected"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.8392553,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 24.2%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/book.js": {
+      "content_hash": [
+        30,
+        107,
+        83,
+        113,
+        9,
+        30,
+        79,
+        191,
+        86,
+        42,
+        114,
+        198,
+        167,
+        106,
+        172,
+        80,
+        202,
+        195,
+        89,
+        153,
+        99,
+        120,
+        92,
+        89,
+        4,
+        46,
+        143,
+        66,
+        151,
+        246,
+        28,
+        108
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/book.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 51 duplicate code patterns"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 5.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent quote usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/framebuffer_benchmark.rs": {
+      "content_hash": [
+        207,
+        175,
+        211,
+        189,
+        192,
+        139,
+        132,
+        199,
+        0,
+        32,
+        180,
+        59,
+        193,
+        166,
+        37,
+        42,
+        116,
+        207,
+        150,
+        197,
+        18,
+        68,
+        107,
+        52,
+        93,
+        138,
+        159,
+        178,
+        11,
+        231,
+        121,
+        121
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 98.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/framebuffer_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/svg_output.rs": {
+      "content_hash": [
+        218,
+        224,
+        235,
+        173,
+        237,
+        34,
+        233,
+        52,
+        159,
+        98,
+        109,
+        86,
+        89,
+        77,
+        198,
+        34,
+        190,
+        151,
+        131,
+        12,
+        63,
+        15,
+        236,
+        18,
+        135,
+        1,
+        22,
+        20,
+        96,
+        230,
+        40,
+        87
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/svg_output.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/meter.rs": {
+      "content_hash": [
+        190,
+        11,
+        232,
+        11,
+        237,
+        127,
+        141,
+        240,
+        185,
+        218,
+        70,
+        71,
+        185,
+        6,
+        249,
+        159,
+        66,
+        160,
+        0,
+        164,
+        148,
+        222,
+        112,
+        43,
+        27,
+        24,
+        254,
+        215,
+        193,
+        158,
+        68,
+        177
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 98.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/meter.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/mode-rust.js": {
+      "content_hash": [
+        101,
+        114,
+        9,
+        51,
+        84,
+        129,
+        17,
+        132,
+        218,
+        236,
+        175,
+        248,
+        140,
+        136,
+        207,
+        253,
+        237,
+        48,
+        77,
+        178,
+        220,
+        103,
+        158,
+        172,
+        110,
+        226,
+        216,
+        224,
+        153,
+        101,
+        176,
+        180
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/mode-rust.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/scale.rs": {
+      "content_hash": [
+        8,
+        33,
+        149,
+        16,
+        49,
+        191,
+        132,
+        211,
+        33,
+        59,
+        80,
+        96,
+        122,
+        44,
+        210,
+        237,
+        130,
+        137,
+        141,
+        212,
+        81,
+        136,
+        241,
+        201,
+        174,
+        179,
+        148,
+        43,
+        176,
+        154,
+        159,
+        93
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.107843,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.82531,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/scale.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 44 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.8921568,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/elasticlunr.min.js": {
+      "content_hash": [
+        193,
+        164,
+        130,
+        94,
+        39,
+        184,
+        85,
+        217,
+        70,
+        25,
+        49,
+        125,
+        50,
+        141,
+        144,
+        181,
+        182,
+        168,
+        106,
+        133,
+        86,
+        71,
+        117,
+        123,
+        77,
+        243,
+        118,
+        189,
+        56,
+        86,
+        110,
+        105
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/elasticlunr.min.js",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/histogram_benchmark.rs": {
+      "content_hash": [
+        95,
+        126,
+        43,
+        0,
+        75,
+        204,
+        197,
+        58,
+        142,
+        42,
+        46,
+        245,
+        98,
+        107,
+        219,
+        126,
+        81,
+        200,
+        248,
+        140,
+        135,
+        206,
+        101,
+        171,
+        76,
+        145,
+        84,
+        196,
+        63,
+        35,
+        8,
+        168
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/histogram_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/widgets/experiment/mod.rs": {
+      "content_hash": [
+        201,
+        228,
+        133,
+        200,
+        103,
+        223,
+        161,
+        44,
+        130,
+        32,
+        205,
+        157,
+        253,
+        254,
+        248,
+        10,
+        219,
+        7,
+        86,
+        15,
+        242,
+        72,
+        253,
+        240,
+        54,
+        104,
+        242,
+        143,
+        19,
+        146,
+        15,
+        227
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/widgets/experiment/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/facet.rs": {
+      "content_hash": [
+        79,
+        185,
+        217,
+        244,
+        149,
+        170,
+        147,
+        33,
+        77,
+        162,
+        99,
+        217,
+        250,
+        3,
+        248,
+        193,
+        94,
+        162,
+        52,
+        149,
+        137,
+        5,
+        215,
+        43,
+        229,
+        202,
+        33,
+        123,
+        58,
+        75,
+        101,
+        163
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.5,
+        "total": 96.81818,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/facet.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/line.rs": {
+      "content_hash": [
+        122,
+        246,
+        245,
+        76,
+        155,
+        123,
+        97,
+        146,
+        249,
+        96,
+        217,
+        16,
+        148,
+        35,
+        171,
+        37,
+        95,
+        165,
+        3,
+        77,
+        1,
+        119,
+        94,
+        154,
+        239,
+        168,
+        104,
+        19,
+        76,
+        215,
+        190,
+        208
+      ],
+      "score": {
+        "structural_complexity": 18.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.874395,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.2744,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/line.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.6000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 37"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.125604,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.6%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 25 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/ace.js": {
+      "content_hash": [
+        163,
+        128,
+        119,
+        150,
+        206,
+        255,
+        145,
+        112,
+        141,
+        191,
+        173,
+        60,
+        84,
+        163,
+        5,
+        236,
+        26,
+        170,
+        229,
+        138,
+        28,
+        235,
+        161,
+        143,
+        25,
+        166,
+        232,
+        227,
+        171,
+        143,
+        250,
+        32
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/ace.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/framebuffer.rs": {
+      "content_hash": [
+        232,
+        146,
+        227,
+        186,
+        33,
+        90,
+        123,
+        173,
+        184,
+        180,
+        3,
+        10,
+        59,
+        100,
+        118,
+        23,
+        255,
+        196,
+        196,
+        230,
+        41,
+        215,
+        135,
+        35,
+        55,
+        209,
+        240,
+        237,
+        85,
+        180,
+        52,
+        102
+      ],
+      "score": {
+        "structural_complexity": 14.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.404922,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.10492,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/framebuffer.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 32"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 31 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5950785,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 13.0%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 46"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/heatmap_benchmark.rs": {
+      "content_hash": [
+        155,
+        222,
+        234,
+        26,
+        170,
+        54,
+        212,
+        225,
+        39,
+        75,
+        153,
+        255,
+        75,
+        69,
+        215,
+        155,
+        71,
+        120,
+        185,
+        231,
+        121,
+        81,
+        150,
+        165,
+        229,
+        160,
+        239,
+        75,
+        181,
+        245,
+        153,
+        235
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.969696,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.69972,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/heatmap_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.030303,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 16 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/cpu_simd.rs": {
+      "content_hash": [
+        61,
+        210,
+        5,
+        201,
+        180,
+        2,
+        109,
+        17,
+        236,
+        116,
+        86,
+        204,
+        146,
+        169,
+        156,
+        144,
+        185,
+        14,
+        137,
+        19,
+        33,
+        97,
+        153,
+        251,
+        242,
+        229,
+        228,
+        135,
+        255,
+        18,
+        229,
+        97
+      ],
+      "score": {
+        "structural_complexity": 20.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.27273,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/cpu_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 23 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.6000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 27"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
     "./crates/ttop/src/state.rs": {
       "content_hash": [
         163,
@@ -53,12 +4591,12 @@
         "file_path": "./crates/ttop/src/state.rs",
         "penalties_applied": [
           {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.3,
+            "source_metric": "Duplication",
+            "amount": 5.0,
             "applied_to": [
-              "StructuralComplexity"
+              "Duplication"
             ],
-            "issue": "High cognitive complexity: 16"
+            "issue": "Found 17 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -67,6 +4605,3959 @@
               "StructuralComplexity"
             ],
             "issue": "High cyclomatic complexity: 95"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 16"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/debug.rs": {
+      "content_hash": [
+        98,
+        37,
+        230,
+        252,
+        173,
+        212,
+        13,
+        88,
+        122,
+        17,
+        215,
+        15,
+        24,
+        51,
+        102,
+        20,
+        112,
+        115,
+        144,
+        205,
+        173,
+        20,
+        21,
+        222,
+        19,
+        6,
+        128,
+        4,
+        81,
+        11,
+        87,
+        151
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/debug.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 17 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/violin.rs": {
+      "content_hash": [
+        228,
+        240,
+        236,
+        226,
+        64,
+        101,
+        191,
+        253,
+        66,
+        18,
+        178,
+        236,
+        160,
+        171,
+        144,
+        228,
+        92,
+        200,
+        10,
+        232,
+        202,
+        67,
+        21,
+        63,
+        184,
+        185,
+        87,
+        3,
+        239,
+        167,
+        157,
+        42
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.417912,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 76.41791,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/violin.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 141"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5820894,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.9%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 71"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 100 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/config.rs": {
+      "content_hash": [
+        25,
+        31,
+        46,
+        90,
+        134,
+        8,
+        78,
+        228,
+        114,
+        66,
+        41,
+        29,
+        209,
+        194,
+        138,
+        194,
+        205,
+        86,
+        145,
+        41,
+        26,
+        156,
+        193,
+        187,
+        95,
+        106,
+        209,
+        151,
+        91,
+        46,
+        41,
+        38
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/config.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/examples/collectors.rs": {
+      "content_hash": [
+        81,
+        251,
+        72,
+        116,
+        181,
+        141,
+        37,
+        48,
+        12,
+        8,
+        22,
+        241,
+        215,
+        16,
+        47,
+        48,
+        199,
+        254,
+        111,
+        205,
+        142,
+        15,
+        72,
+        114,
+        62,
+        156,
+        141,
+        203,
+        195,
+        250,
+        0,
+        108
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/examples/collectors.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/gpu_apple.rs": {
+      "content_hash": [
+        61,
+        35,
+        84,
+        238,
+        104,
+        98,
+        61,
+        50,
+        138,
+        22,
+        198,
+        244,
+        71,
+        27,
+        206,
+        87,
+        72,
+        243,
+        37,
+        153,
+        124,
+        114,
+        198,
+        82,
+        41,
+        13,
+        182,
+        35,
+        76,
+        33,
+        46,
+        179
+      ],
+      "score": {
+        "structural_complexity": 6.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 86.5,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/gpu_apple.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 41"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 7 levels"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 122"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 22 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/output/png_encoder.rs": {
+      "content_hash": [
+        241,
+        103,
+        61,
+        128,
+        25,
+        147,
+        217,
+        212,
+        30,
+        0,
+        215,
+        158,
+        36,
+        212,
+        160,
+        129,
+        183,
+        174,
+        57,
+        95,
+        19,
+        39,
+        43,
+        0,
+        49,
+        173,
+        35,
+        25,
+        145,
+        255,
+        212,
+        180
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.0,
+        "total": 96.36363,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/output/png_encoder.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 8 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/disk_simd.rs": {
+      "content_hash": [
+        100,
+        249,
+        111,
+        240,
+        163,
+        207,
+        1,
+        152,
+        247,
+        130,
+        240,
+        244,
+        114,
+        131,
+        108,
+        41,
+        18,
+        42,
+        122,
+        232,
+        137,
+        10,
+        221,
+        103,
+        87,
+        137,
+        143,
+        28,
+        241,
+        120,
+        183,
+        75
+      ],
+      "score": {
+        "structural_complexity": 23.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.818184,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/disk_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.8000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 21"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 16 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/interop/entrenar.rs": {
+      "content_hash": [
+        198,
+        0,
+        61,
+        125,
+        60,
+        89,
+        162,
+        89,
+        70,
+        52,
+        241,
+        206,
+        187,
+        244,
+        235,
+        239,
+        111,
+        110,
+        254,
+        111,
+        18,
+        182,
+        186,
+        123,
+        60,
+        127,
+        35,
+        192,
+        42,
+        201,
+        23,
+        34
+      ],
+      "score": {
+        "structural_complexity": 12.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.035929,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 89.23593,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/interop/entrenar.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 46"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 63 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.964072,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.8%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 37"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/src/lib.rs": {
+      "content_hash": [
+        164,
+        18,
+        104,
+        114,
+        136,
+        161,
+        71,
+        192,
+        222,
+        219,
+        40,
+        35,
+        80,
+        25,
+        30,
+        135,
+        136,
+        144,
+        149,
+        43,
+        30,
+        61,
+        68,
+        226,
+        137,
+        65,
+        194,
+        99,
+        136,
+        161,
+        18,
+        116
+      ],
+      "score": {
+        "structural_complexity": 22.3,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.188604,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 98.4886,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./wasm-pkg/src/lib.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 60 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.811395,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 19.1%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.7,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 24"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/process_simd.rs": {
+      "content_hash": [
+        72,
+        159,
+        64,
+        25,
+        53,
+        171,
+        139,
+        20,
+        84,
+        161,
+        26,
+        187,
+        158,
+        129,
+        70,
+        170,
+        240,
+        253,
+        241,
+        167,
+        239,
+        228,
+        68,
+        220,
+        42,
+        44,
+        195,
+        146,
+        155,
+        47,
+        218,
+        81
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.068274,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.78934,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/process_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 42 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.931727,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/force_graph.rs": {
+      "content_hash": [
+        37,
+        63,
+        222,
+        83,
+        121,
+        146,
+        204,
+        164,
+        98,
+        54,
+        113,
+        178,
+        33,
+        40,
+        144,
+        232,
+        162,
+        94,
+        54,
+        112,
+        97,
+        205,
+        196,
+        49,
+        42,
+        233,
+        159,
+        209,
+        225,
+        44,
+        76,
+        215
+      ],
+      "score": {
+        "structural_complexity": 22.6,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.997578,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.59758,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/force_graph.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.4,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 23"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0024214,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 31 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/storage.rs": {
+      "content_hash": [
+        184,
+        198,
+        231,
+        30,
+        116,
+        208,
+        165,
+        55,
+        130,
+        57,
+        147,
+        43,
+        121,
+        158,
+        115,
+        206,
+        46,
+        66,
+        216,
+        143,
+        239,
+        44,
+        112,
+        149,
+        206,
+        79,
+        181,
+        254,
+        20,
+        60,
+        35,
+        205
+      ],
+      "score": {
+        "structural_complexity": 18.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.935102,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.335106,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/storage.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0648968,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.3%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.6000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 37"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 46 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/ffi/afterburner.rs": {
+      "content_hash": [
+        30,
+        230,
+        1,
+        205,
+        113,
+        34,
+        34,
+        198,
+        135,
+        211,
+        145,
+        17,
+        112,
+        176,
+        62,
+        248,
+        49,
+        35,
+        62,
+        220,
+        26,
+        31,
+        57,
+        60,
+        162,
+        135,
+        220,
+        222,
+        219,
+        195,
+        72,
+        160
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/ffi/afterburner.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/ring_buffer.rs": {
+      "content_hash": [
+        43,
+        167,
+        166,
+        133,
+        8,
+        60,
+        179,
+        75,
+        151,
+        248,
+        221,
+        77,
+        78,
+        201,
+        176,
+        155,
+        35,
+        237,
+        161,
+        155,
+        217,
+        97,
+        213,
+        192,
+        204,
+        19,
+        53,
+        24,
+        142,
+        55,
+        235,
+        223
+      ],
+      "score": {
+        "structural_complexity": 22.3,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.902655,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.20265,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/ring_buffer.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0973454,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.5%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.7,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 24"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 30 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/app/mod.rs": {
+      "content_hash": [
+        76,
+        140,
+        179,
+        207,
+        215,
+        223,
+        246,
+        254,
+        239,
+        128,
+        7,
+        175,
+        155,
+        159,
+        126,
+        155,
+        77,
+        42,
+        44,
+        66,
+        7,
+        233,
+        244,
+        188,
+        121,
+        87,
+        181,
+        163,
+        104,
+        21,
+        238,
+        55
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.848791,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 77.84879,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/app/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 185"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.1512082,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.8%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 174"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 93 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/histogram.rs": {
+      "content_hash": [
+        158,
+        140,
+        157,
+        37,
+        186,
+        105,
+        46,
+        87,
+        22,
+        246,
+        94,
+        10,
+        115,
+        23,
+        253,
+        5,
+        51,
+        237,
+        210,
+        126,
+        75,
+        215,
+        67,
+        112,
+        232,
+        237,
+        35,
+        102,
+        220,
+        11,
+        152,
+        216
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.23036,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 77.23036,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/histogram.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 14.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 58"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 106"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 49 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.7696404,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 13.8%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./tests/wgpu_multi_gpu_test.rs": {
+      "content_hash": [
+        162,
+        220,
+        255,
+        120,
+        161,
+        239,
+        186,
+        252,
+        150,
+        51,
+        192,
+        42,
+        183,
+        77,
+        97,
+        13,
+        40,
+        148,
+        104,
+        161,
+        163,
+        57,
+        104,
+        242,
+        139,
+        143,
+        156,
+        88,
+        10,
+        106,
+        43,
+        94
+      ],
+      "score": {
+        "structural_complexity": 24.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.028986,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 98.72899,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./tests/wgpu_multi_gpu_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 16"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 27 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.9710145,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 29.9%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/theme.rs": {
+      "content_hash": [
+        70,
+        101,
+        222,
+        19,
+        181,
+        196,
+        206,
+        92,
+        141,
+        237,
+        126,
+        115,
+        246,
+        252,
+        126,
+        161,
+        165,
+        196,
+        187,
+        24,
+        204,
+        93,
+        21,
+        156,
+        56,
+        172,
+        104,
+        72,
+        68,
+        114,
+        197,
+        175
+      ],
+      "score": {
+        "structural_complexity": 16.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.7,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/theme.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.3,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 36"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/examples/simple.rs": {
+      "content_hash": [
+        60,
+        144,
+        180,
+        215,
+        229,
+        80,
+        142,
+        121,
+        27,
+        57,
+        36,
+        216,
+        125,
+        212,
+        152,
+        251,
+        56,
+        87,
+        49,
+        252,
+        231,
+        187,
+        41,
+        26,
+        205,
+        15,
+        4,
+        233,
+        73,
+        173,
+        215,
+        133
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/examples/simple.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/ffi/wgpu.rs": {
+      "content_hash": [
+        157,
+        228,
+        109,
+        230,
+        117,
+        20,
+        139,
+        128,
+        216,
+        74,
+        179,
+        110,
+        178,
+        164,
+        60,
+        71,
+        37,
+        199,
+        135,
+        158,
+        22,
+        126,
+        23,
+        41,
+        51,
+        55,
+        233,
+        222,
+        174,
+        160,
+        49,
+        184
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.084549,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.80413,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/ffi/wgpu.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 34 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.9154518,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.6%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/ui.rs": {
+      "content_hash": [
+        188,
+        245,
+        24,
+        208,
+        119,
+        125,
+        188,
+        79,
+        235,
+        242,
+        76,
+        123,
+        212,
+        159,
+        66,
+        71,
+        244,
+        70,
+        254,
+        68,
+        210,
+        110,
+        191,
+        54,
+        254,
+        21,
+        49,
+        19,
+        129,
+        28,
+        43,
+        255
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 13.991632,
+        "coupling_score": 12.2,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 71.191635,
+        "grade": "BMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/ui.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 113 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 81"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 6.008368,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 30.0%"
+          },
+          {
+            "source_metric": "Coupling",
+            "amount": 2.8,
+            "applied_to": [
+              "Coupling"
+            ],
+            "issue": "Too many imports: 34"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 87"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/probar_full_test.rs": {
+      "content_hash": [
+        218,
+        46,
+        86,
+        54,
+        116,
+        200,
+        187,
+        17,
+        66,
+        188,
+        28,
+        100,
+        219,
+        49,
+        9,
+        130,
+        131,
+        41,
+        99,
+        91,
+        140,
+        191,
+        77,
+        37,
+        56,
+        168,
+        196,
+        125,
+        72,
+        80,
+        0,
+        4
+      ],
+      "score": {
+        "structural_complexity": 21.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.950531,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.05053,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/probar_full_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 24 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.9,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 28"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.04947,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.2%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/timeseries.rs": {
+      "content_hash": [
+        57,
+        117,
+        255,
+        26,
+        122,
+        85,
+        214,
+        87,
+        120,
+        244,
+        78,
+        12,
+        66,
+        9,
+        231,
+        91,
+        164,
+        102,
+        86,
+        228,
+        168,
+        128,
+        66,
+        103,
+        116,
+        154,
+        58,
+        130,
+        101,
+        3,
+        237,
+        55
+      ],
+      "score": {
+        "structural_complexity": 6.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 86.0,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/timeseries.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 80"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 48"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 35 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/dashboard_widgets.rs": {
+      "content_hash": [
+        107,
+        199,
+        247,
+        10,
+        138,
+        176,
+        11,
+        177,
+        69,
+        133,
+        143,
+        187,
+        164,
+        26,
+        103,
+        159,
+        78,
+        212,
+        137,
+        171,
+        172,
+        88,
+        6,
+        62,
+        125,
+        225,
+        207,
+        83,
+        112,
+        16,
+        3,
+        52
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/dashboard_widgets.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/aprender_integration.rs": {
+      "content_hash": [
+        56,
+        236,
+        216,
+        1,
+        31,
+        250,
+        141,
+        239,
+        58,
+        205,
+        103,
+        245,
+        66,
+        255,
+        58,
+        145,
+        32,
+        41,
+        128,
+        38,
+        176,
+        248,
+        95,
+        224,
+        247,
+        26,
+        119,
+        6,
+        108,
+        142,
+        97,
+        229
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/aprender_integration.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/line_benchmark.rs": {
+      "content_hash": [
+        252,
+        69,
+        205,
+        216,
+        226,
+        129,
+        138,
+        51,
+        191,
+        128,
+        145,
+        235,
+        132,
+        239,
+        1,
+        57,
+        166,
+        231,
+        242,
+        108,
+        51,
+        151,
+        90,
+        164,
+        179,
+        48,
+        66,
+        210,
+        109,
+        72,
+        209,
+        3
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.209303,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.91755,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/line_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 13 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.7906978,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.0%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/tree.rs": {
+      "content_hash": [
+        144,
+        104,
+        16,
+        145,
+        118,
+        236,
+        2,
+        248,
+        150,
+        108,
+        35,
+        59,
+        30,
+        37,
+        215,
+        71,
+        171,
+        244,
+        123,
+        191,
+        247,
+        134,
+        47,
+        148,
+        220,
+        242,
+        73,
+        4,
+        30,
+        193,
+        99,
+        52
+      ],
+      "score": {
+        "structural_complexity": 23.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.094675,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.29468,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/tree.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 26 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.8000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 21"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.9053254,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 19.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/accel/mod.rs": {
+      "content_hash": [
+        138,
+        135,
+        39,
+        62,
+        192,
+        204,
+        169,
+        55,
+        47,
+        8,
+        183,
+        56,
+        171,
+        149,
+        156,
+        100,
+        151,
+        134,
+        7,
+        167,
+        40,
+        144,
+        164,
+        83,
+        131,
+        149,
+        74,
+        235,
+        246,
+        95,
+        22,
+        62
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/accel/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/display_rules.rs": {
+      "content_hash": [
+        33,
+        104,
+        0,
+        226,
+        39,
+        21,
+        25,
+        68,
+        66,
+        19,
+        145,
+        25,
+        121,
+        101,
+        78,
+        116,
+        141,
+        29,
+        144,
+        254,
+        139,
+        161,
+        133,
+        104,
+        24,
+        73,
+        91,
+        0,
+        244,
+        32,
+        111,
+        22
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/display_rules.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/main.rs": {
+      "content_hash": [
+        246,
+        239,
+        28,
+        1,
+        108,
+        181,
+        68,
+        145,
+        78,
+        42,
+        157,
+        183,
+        174,
+        125,
+        215,
+        176,
+        32,
+        85,
+        197,
+        72,
+        160,
+        138,
+        64,
+        16,
+        161,
+        16,
+        73,
+        162,
+        122,
+        121,
+        81,
+        52
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/main.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/playbook_test.rs": {
+      "content_hash": [
+        148,
+        4,
+        197,
+        95,
+        177,
+        172,
+        127,
+        28,
+        173,
+        243,
+        200,
+        164,
+        58,
+        100,
+        235,
+        119,
+        85,
+        133,
+        20,
+        14,
+        101,
+        206,
+        18,
+        29,
+        195,
+        35,
+        200,
+        224,
+        224,
+        219,
+        57,
+        29
+      ],
+      "score": {
+        "structural_complexity": 11.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.99591,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 88.99591,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/playbook_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 4.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 38"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 43 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0040898,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.0%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 72"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/kernels.rs": {
+      "content_hash": [
+        224,
+        104,
+        31,
+        200,
+        204,
+        240,
+        33,
+        99,
+        78,
+        13,
+        123,
+        106,
+        205,
+        1,
+        225,
+        239,
+        99,
+        28,
+        159,
+        183,
+        3,
+        12,
+        13,
+        9,
+        187,
+        182,
+        32,
+        131,
+        41,
+        229,
+        254,
+        206
+      ],
+      "score": {
+        "structural_complexity": 18.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.82927,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.92927,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/kernels.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.9,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 38"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1707315,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.9%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 23 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/box_violin.rs": {
+      "content_hash": [
+        163,
+        208,
+        156,
+        78,
+        100,
+        107,
+        225,
+        27,
+        21,
+        216,
+        227,
+        194,
+        47,
+        228,
+        109,
+        181,
+        221,
+        233,
+        0,
+        55,
+        53,
+        218,
+        218,
+        246,
+        252,
+        201,
+        189,
+        122,
+        83,
+        104,
+        131,
+        52
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.906977,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.551796,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/box_violin.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0930233,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.5%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/panels/disk.rs": {
+      "content_hash": [
+        160,
+        12,
+        245,
+        121,
+        71,
+        36,
+        83,
+        108,
+        187,
+        205,
+        124,
+        153,
+        160,
+        41,
+        176,
+        92,
+        70,
+        151,
+        128,
+        108,
+        196,
+        37,
+        83,
+        169,
+        74,
+        38,
+        65,
+        9,
+        215,
+        128,
+        101,
+        142
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/panels/disk.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/loss_training.rs": {
+      "content_hash": [
+        219,
+        153,
+        86,
+        192,
+        62,
+        25,
+        61,
+        169,
+        15,
+        227,
+        221,
+        102,
+        122,
+        43,
+        28,
+        157,
+        163,
+        33,
+        25,
+        18,
+        253,
+        229,
+        235,
+        50,
+        121,
+        231,
+        41,
+        229,
+        198,
+        118,
+        185,
+        1
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/loss_training.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/panels/network.rs": {
+      "content_hash": [
+        254,
+        10,
+        35,
+        134,
+        66,
+        124,
+        195,
+        140,
+        46,
+        18,
+        90,
+        206,
+        65,
+        44,
+        92,
+        176,
+        222,
+        202,
+        168,
+        85,
+        126,
+        75,
+        236,
+        66,
+        90,
+        136,
+        248,
+        240,
+        77,
+        151,
+        28,
+        183
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/panels/network.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/network_simd.rs": {
+      "content_hash": [
+        58,
+        41,
+        27,
+        215,
+        14,
+        233,
+        83,
+        14,
+        174,
+        229,
+        4,
+        129,
+        131,
+        19,
+        171,
+        247,
+        188,
+        11,
+        41,
+        90,
+        151,
+        34,
+        100,
+        60,
+        214,
+        119,
+        204,
+        207,
+        135,
+        52,
+        225,
+        117
+      ],
+      "score": {
+        "structural_complexity": 22.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.747253,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.74725,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/network_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.2527473,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.3%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 25"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 24 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/render/mod.rs": {
+      "content_hash": [
+        172,
+        192,
+        75,
+        78,
+        75,
+        92,
+        39,
+        80,
+        91,
+        136,
+        117,
+        244,
+        82,
+        83,
+        197,
+        222,
+        128,
+        136,
+        104,
+        204,
+        77,
+        157,
+        37,
+        27,
+        201,
+        100,
+        6,
+        164,
+        163,
+        241,
+        233,
+        72
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/render/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/wasm.rs": {
+      "content_hash": [
+        87,
+        186,
+        175,
+        49,
+        36,
+        114,
+        184,
+        214,
+        18,
+        118,
+        180,
+        105,
+        63,
+        246,
+        9,
+        195,
+        191,
+        48,
+        198,
+        131,
+        212,
+        39,
+        232,
+        113,
+        221,
+        114,
+        60,
+        86,
+        79,
+        9,
+        45,
+        166
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.844156,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.676506,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/wasm.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.155844,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 20.8%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/kernels.rs": {
+      "content_hash": [
+        230,
+        148,
+        70,
+        84,
+        37,
+        245,
+        185,
+        236,
+        157,
+        78,
+        150,
+        108,
+        42,
+        113,
+        96,
+        69,
+        196,
+        83,
+        13,
+        241,
+        221,
+        220,
+        113,
+        176,
+        48,
+        137,
+        57,
+        193,
+        67,
+        51,
+        180,
+        181
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.034733,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 76.03473,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/kernels.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 85"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 65"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.965268,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 19.8%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 64 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/containers.rs": {
+      "content_hash": [
+        178,
+        133,
+        172,
+        189,
+        10,
+        185,
+        95,
+        47,
+        11,
+        253,
+        184,
+        174,
+        166,
+        9,
+        184,
+        175,
+        245,
+        98,
+        31,
+        89,
+        112,
+        193,
+        232,
+        252,
+        198,
+        94,
+        113,
+        78,
+        42,
+        54,
+        129,
+        55
+      ],
+      "score": {
+        "structural_complexity": 23.8,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.36364,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/containers.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 24 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.2,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 19"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/panels/mod.rs": {
+      "content_hash": [
+        64,
+        130,
+        33,
+        168,
+        168,
+        56,
+        165,
+        126,
+        72,
+        248,
+        152,
+        244,
+        159,
+        33,
+        181,
+        248,
+        253,
+        47,
+        181,
+        125,
+        195,
+        121,
+        180,
+        222,
+        122,
+        73,
+        21,
+        72,
+        193,
+        249,
+        17,
+        192
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/panels/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/dataframe.rs": {
+      "content_hash": [
+        83,
+        192,
+        55,
+        206,
+        141,
+        197,
+        218,
+        135,
+        160,
+        131,
+        251,
+        19,
+        242,
+        155,
+        227,
+        186,
+        244,
+        80,
+        209,
+        153,
+        49,
+        189,
+        187,
+        187,
+        221,
+        54,
+        167,
+        63,
+        245,
+        139,
+        146,
+        138
+      ],
+      "score": {
+        "structural_complexity": 0.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.732998,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 78.233,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/dataframe.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 12.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 55"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.2670026,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.3%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 105"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 48 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/battery.rs": {
+      "content_hash": [
+        228,
+        63,
+        4,
+        169,
+        136,
+        61,
+        108,
+        106,
+        121,
+        191,
+        204,
+        171,
+        38,
+        213,
+        133,
+        166,
+        158,
+        244,
+        241,
+        66,
+        91,
+        29,
+        191,
+        111,
+        171,
+        203,
+        225,
+        165,
+        88,
+        120,
+        89,
+        246
+      ],
+      "score": {
+        "structural_complexity": 21.9,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.579573,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 98.479576,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/battery.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.1000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 22"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 32 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 32"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.4204273,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.1%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/bin/trueno_monitor.rs": {
+      "content_hash": [
+        250,
+        9,
+        35,
+        244,
+        222,
+        78,
+        49,
+        93,
+        252,
+        65,
+        51,
+        17,
+        80,
+        186,
+        165,
+        93,
+        163,
+        48,
+        189,
+        112,
+        166,
+        124,
+        166,
+        200,
+        17,
+        165,
+        23,
+        61,
+        125,
+        190,
+        255,
+        219
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/bin/trueno_monitor.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/grammar_of_graphics.rs": {
+      "content_hash": [
+        182,
+        214,
+        178,
+        28,
+        145,
+        208,
+        83,
+        44,
+        29,
+        55,
+        96,
+        23,
+        114,
+        203,
+        222,
+        55,
+        32,
+        253,
+        109,
+        195,
+        0,
+        47,
+        183,
+        109,
+        53,
+        124,
+        43,
+        57,
+        57,
+        216,
+        155,
+        18
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.462585,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.23871,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/grammar_of_graphics.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 13 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.537415,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/battery_sensors_simd.rs": {
+      "content_hash": [
+        73,
+        221,
+        154,
+        226,
+        243,
+        144,
+        55,
+        22,
+        168,
+        217,
+        203,
+        243,
+        56,
+        153,
+        197,
+        69,
+        98,
+        244,
+        128,
+        48,
+        26,
+        71,
+        212,
+        145,
+        168,
+        72,
+        58,
+        104,
+        188,
+        224,
+        55,
+        96
+      ],
+      "score": {
+        "structural_complexity": 23.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.956657,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.23332,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/battery_sensors_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 18 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0433435,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.2%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 20"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/confusion.rs": {
+      "content_hash": [
+        70,
+        200,
+        202,
+        214,
+        23,
+        23,
+        208,
+        134,
+        219,
+        187,
+        224,
+        30,
+        40,
+        138,
+        30,
+        50,
+        21,
+        34,
+        155,
+        73,
+        6,
+        61,
+        179,
+        171,
+        255,
+        97,
+        215,
+        65,
+        44,
+        110,
+        150,
+        15
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.871239,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 76.87124,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/confusion.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 111"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1287603,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.6%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 67"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 49 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/confusion_matrix_ml.rs": {
+      "content_hash": [
+        97,
+        187,
+        72,
+        241,
+        136,
+        182,
+        78,
+        0,
+        112,
+        163,
+        131,
+        106,
+        187,
+        122,
+        168,
+        24,
+        217,
+        225,
+        9,
+        6,
+        46,
+        78,
+        97,
+        32,
+        90,
+        51,
+        212,
+        125,
+        97,
+        247,
+        167,
+        138
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.52174,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.292496,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/confusion_matrix_ml.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.478261,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.4%"
           },
           {
             "source_metric": "Duplication",
@@ -89,70 +8580,62 @@
       },
       "git_context": null
     },
-    "./tests/collectors_macos_test.rs": {
+    "./src/monitor/panels/memory.rs": {
       "content_hash": [
-        207,
-        122,
-        139,
-        102,
-        86,
-        36,
-        190,
-        130,
-        81,
-        28,
-        104,
-        94,
-        24,
-        80,
-        240,
-        170,
-        53,
-        214,
-        84,
-        245,
-        91,
+        98,
+        187,
+        16,
         9,
-        126,
-        28,
-        90,
-        252,
-        136,
-        37,
-        115,
-        156,
-        90,
-        4
+        94,
+        225,
+        117,
+        196,
+        117,
+        204,
+        100,
+        23,
+        87,
+        235,
+        108,
+        119,
+        170,
+        123,
+        58,
+        113,
+        255,
+        243,
+        100,
+        72,
+        47,
+        6,
+        166,
+        186,
+        205,
+        190,
+        77,
+        163
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.884422,
+        "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.6222,
-        "grade": "A",
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
         "confidence": 1.0,
         "language": "Rust",
-        "file_path": "./tests/collectors_macos_test.rs",
+        "file_path": "./src/monitor/panels/memory.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 3.115578,
+            "amount": 1.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 15.6%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 28 duplicate code patterns"
+            "issue": "Found 2 duplicate code patterns"
           }
         ],
         "critical_defects_count": 0,
@@ -237,6 +8720,1711 @@
       },
       "git_context": null
     },
+    "./src/monitor/simd/compressed.rs": {
+      "content_hash": [
+        51,
+        231,
+        246,
+        229,
+        210,
+        127,
+        53,
+        88,
+        207,
+        146,
+        154,
+        67,
+        118,
+        29,
+        233,
+        106,
+        210,
+        110,
+        213,
+        115,
+        205,
+        10,
+        193,
+        93,
+        40,
+        126,
+        177,
+        107,
+        2,
+        231,
+        79,
+        204
+      ],
+      "score": {
+        "structural_complexity": 20.8,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.63637,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/compressed.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 4.2000003,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 29"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 14 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/confusion_matrix.rs": {
+      "content_hash": [
+        76,
+        68,
+        91,
+        54,
+        22,
+        61,
+        165,
+        84,
+        183,
+        246,
+        95,
+        141,
+        65,
+        154,
+        169,
+        171,
+        30,
+        246,
+        186,
+        167,
+        218,
+        239,
+        233,
+        112,
+        2,
+        102,
+        46,
+        182,
+        133,
+        181,
+        11,
+        232
+      ],
+      "score": {
+        "structural_complexity": 13.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.485508,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 89.485504,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/confusion_matrix.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 36 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5144928,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.6%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 50"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 34"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/disk_io.rs": {
+      "content_hash": [
+        70,
+        89,
+        218,
+        225,
+        215,
+        54,
+        76,
+        169,
+        167,
+        140,
+        197,
+        131,
+        70,
+        248,
+        31,
+        168,
+        112,
+        94,
+        57,
+        187,
+        214,
+        242,
+        97,
+        41,
+        135,
+        167,
+        27,
+        191,
+        91,
+        156,
+        53,
+        169
+      ],
+      "score": {
+        "structural_complexity": 24.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.90909,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/disk_io.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 17"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 29 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/process_extra.rs": {
+      "content_hash": [
+        249,
+        194,
+        210,
+        58,
+        37,
+        142,
+        229,
+        146,
+        33,
+        10,
+        124,
+        9,
+        68,
+        61,
+        230,
+        166,
+        39,
+        224,
+        179,
+        67,
+        186,
+        7,
+        60,
+        209,
+        146,
+        156,
+        203,
+        160,
+        83,
+        113,
+        0,
+        120
+      ],
+      "score": {
+        "structural_complexity": 15.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.468172,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.46817,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/process_extra.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 43 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5318277,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 17.7%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 63"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/trueno_graph_integration.rs": {
+      "content_hash": [
+        177,
+        25,
+        150,
+        200,
+        110,
+        174,
+        38,
+        243,
+        244,
+        90,
+        135,
+        232,
+        81,
+        34,
+        254,
+        34,
+        64,
+        89,
+        78,
+        132,
+        28,
+        176,
+        91,
+        189,
+        17,
+        198,
+        0,
+        170,
+        163,
+        226,
+        7,
+        20
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/trueno_graph_integration.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/mod.rs": {
+      "content_hash": [
+        172,
+        100,
+        98,
+        105,
+        232,
+        53,
+        110,
+        50,
+        94,
+        10,
+        26,
+        191,
+        36,
+        90,
+        101,
+        220,
+        198,
+        25,
+        228,
+        228,
+        162,
+        211,
+        81,
+        231,
+        129,
+        32,
+        249,
+        59,
+        28,
+        126,
+        78,
+        22
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./tests/collectors_macos_test.rs": {
+      "content_hash": [
+        207,
+        122,
+        139,
+        102,
+        86,
+        36,
+        190,
+        130,
+        81,
+        28,
+        104,
+        94,
+        24,
+        80,
+        240,
+        170,
+        53,
+        214,
+        84,
+        245,
+        91,
+        9,
+        126,
+        28,
+        90,
+        252,
+        136,
+        37,
+        115,
+        156,
+        90,
+        4
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.884422,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.6222,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./tests/collectors_macos_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 28 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.115578,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.6%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/aes.rs": {
+      "content_hash": [
+        216,
+        236,
+        30,
+        234,
+        46,
+        36,
+        15,
+        8,
+        244,
+        135,
+        245,
+        68,
+        219,
+        247,
+        90,
+        131,
+        121,
+        51,
+        37,
+        128,
+        18,
+        172,
+        163,
+        229,
+        155,
+        79,
+        53,
+        203,
+        55,
+        180,
+        154,
+        188
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 98.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/aes.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/panels/mod.rs": {
+      "content_hash": [
+        74,
+        170,
+        252,
+        34,
+        59,
+        39,
+        159,
+        254,
+        90,
+        40,
+        63,
+        197,
+        57,
+        131,
+        127,
+        8,
+        152,
+        184,
+        71,
+        241,
+        88,
+        231,
+        125,
+        126,
+        130,
+        245,
+        200,
+        195,
+        109,
+        235,
+        133,
+        33
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/panels/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/mod.rs": {
+      "content_hash": [
+        20,
+        145,
+        157,
+        251,
+        161,
+        249,
+        205,
+        79,
+        9,
+        68,
+        201,
+        69,
+        188,
+        145,
+        252,
+        102,
+        45,
+        163,
+        100,
+        110,
+        50,
+        92,
+        147,
+        90,
+        154,
+        191,
+        91,
+        3,
+        125,
+        92,
+        76,
+        163
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/correlation.rs": {
+      "content_hash": [
+        163,
+        106,
+        81,
+        54,
+        70,
+        63,
+        213,
+        1,
+        130,
+        60,
+        182,
+        122,
+        25,
+        200,
+        182,
+        145,
+        137,
+        117,
+        16,
+        27,
+        229,
+        83,
+        135,
+        69,
+        20,
+        48,
+        28,
+        59,
+        175,
+        142,
+        232,
+        238
+      ],
+      "score": {
+        "structural_complexity": 14.9,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.9,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/correlation.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 47"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 31"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 21 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/disk_entropy.rs": {
+      "content_hash": [
+        159,
+        106,
+        187,
+        238,
+        158,
+        83,
+        83,
+        160,
+        5,
+        250,
+        9,
+        85,
+        181,
+        155,
+        191,
+        46,
+        147,
+        15,
+        97,
+        184,
+        97,
+        123,
+        122,
+        53,
+        209,
+        108,
+        116,
+        234,
+        25,
+        253,
+        178,
+        197
+      ],
+      "score": {
+        "structural_complexity": 9.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.860214,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 86.360214,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/disk_entropy.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1397848,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 47 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 4.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 39"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 76"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/scatter_basic.rs": {
+      "content_hash": [
+        145,
+        74,
+        164,
+        42,
+        93,
+        8,
+        202,
+        244,
+        240,
+        205,
+        18,
+        22,
+        158,
+        224,
+        215,
+        156,
+        70,
+        88,
+        166,
+        207,
+        188,
+        129,
+        182,
+        6,
+        140,
+        76,
+        180,
+        17,
+        125,
+        152,
+        168,
+        56
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/scatter_basic.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/output/terminal.rs": {
+      "content_hash": [
+        86,
+        219,
+        18,
+        182,
+        36,
+        30,
+        162,
+        152,
+        217,
+        116,
+        93,
+        219,
+        249,
+        6,
+        163,
+        2,
+        64,
+        254,
+        9,
+        224,
+        167,
+        61,
+        241,
+        107,
+        34,
+        162,
+        103,
+        49,
+        235,
+        62,
+        205,
+        243
+      ],
+      "score": {
+        "structural_complexity": 21.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.164179,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 98.86418,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/output/terminal.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.3000002,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 26"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 26 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.835821,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.2%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/theme.rs": {
+      "content_hash": [
+        39,
+        184,
+        153,
+        10,
+        41,
+        216,
+        28,
+        192,
+        117,
+        200,
+        134,
+        99,
+        108,
+        29,
+        11,
+        252,
+        48,
+        87,
+        195,
+        197,
+        220,
+        12,
+        194,
+        6,
+        96,
+        179,
+        71,
+        85,
+        226,
+        70,
+        229,
+        231
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/theme.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/mod.rs": {
+      "content_hash": [
+        61,
+        178,
+        50,
+        84,
+        225,
+        185,
+        186,
+        84,
+        104,
+        19,
+        174,
+        116,
+        121,
+        140,
+        246,
+        25,
+        158,
+        52,
+        135,
+        25,
+        228,
+        252,
+        121,
+        138,
+        234,
+        183,
+        118,
+        49,
+        23,
+        83,
+        182,
+        178
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./pkg/trueno_viz.d.ts": {
+      "content_hash": [
+        42,
+        130,
+        185,
+        136,
+        93,
+        178,
+        119,
+        219,
+        156,
+        51,
+        115,
+        102,
+        218,
+        245,
+        3,
+        162,
+        143,
+        109,
+        99,
+        107,
+        237,
+        91,
+        212,
+        26,
+        248,
+        34,
+        203,
+        107,
+        167,
+        209,
+        141,
+        123
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.59036,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.26397,
+        "grade": "A",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./pkg/trueno_viz.d.ts",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.4096386,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 10 duplicate code patterns"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/sensor_health.rs": {
+      "content_hash": [
+        152,
+        122,
+        157,
+        25,
+        1,
+        161,
+        251,
+        137,
+        24,
+        190,
+        66,
+        79,
+        53,
+        210,
+        107,
+        187,
+        12,
+        16,
+        11,
+        203,
+        123,
+        129,
+        112,
+        16,
+        51,
+        145,
+        247,
+        177,
+        242,
+        29,
+        248,
+        217
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.382374,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 75.38237,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/sensor_health.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 91"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 125 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.6176257,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 23.1%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 89"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/verification_specs.rs": {
+      "content_hash": [
+        139,
+        102,
+        214,
+        190,
+        26,
+        234,
+        246,
+        91,
+        230,
+        22,
+        92,
+        208,
+        127,
+        13,
+        140,
+        94,
+        171,
+        89,
+        60,
+        38,
+        251,
+        143,
+        96,
+        154,
+        151,
+        112,
+        219,
+        249,
+        139,
+        27,
+        242,
+        191
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.0,
+        "total": 97.27273,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/verification_specs.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 6 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/process.rs": {
+      "content_hash": [
+        28,
+        203,
+        173,
+        176,
+        25,
+        242,
+        144,
+        144,
+        67,
+        106,
+        96,
+        75,
+        167,
+        33,
+        20,
+        116,
+        169,
+        81,
+        134,
+        246,
+        218,
+        101,
+        49,
+        46,
+        194,
+        21,
+        225,
+        246,
+        12,
+        135,
+        62,
+        228
+      ],
+      "score": {
+        "structural_complexity": 20.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.090904,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/process.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 36"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.8000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 21"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 39 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/ffi/iokit.rs": {
+      "content_hash": [
+        254,
+        221,
+        98,
+        167,
+        101,
+        191,
+        74,
+        211,
+        120,
+        106,
+        93,
+        241,
+        154,
+        124,
+        194,
+        111,
+        206,
+        241,
+        224,
+        131,
+        152,
+        133,
+        183,
+        1,
+        55,
+        247,
+        119,
+        149,
+        118,
+        110,
+        234,
+        154
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/ffi/iokit.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/pkg/trueno_viz_wasm_bg.wasm.d.ts": {
+      "content_hash": [
+        175,
+        138,
+        164,
+        33,
+        5,
+        130,
+        139,
+        253,
+        41,
+        233,
+        32,
+        95,
+        119,
+        88,
+        197,
+        150,
+        253,
+        208,
+        154,
+        46,
+        75,
+        230,
+        216,
+        64,
+        192,
+        255,
+        70,
+        107,
+        128,
+        255,
+        3,
+        113
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm_bg.wasm.d.ts",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
     "./examples/simd_kernels.rs": {
       "content_hash": [
         85,
@@ -301,6 +10489,5272 @@
               "Duplication"
             ],
             "issue": "Code duplication: 12.0%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/roc_pr.rs": {
+      "content_hash": [
+        42,
+        56,
+        208,
+        199,
+        226,
+        242,
+        9,
+        88,
+        40,
+        253,
+        124,
+        11,
+        169,
+        184,
+        80,
+        54,
+        88,
+        247,
+        199,
+        180,
+        212,
+        137,
+        20,
+        52,
+        13,
+        165,
+        61,
+        238,
+        216,
+        143,
+        61,
+        83
+      ],
+      "score": {
+        "structural_complexity": 22.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.605954,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.60596,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/roc_pr.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 25"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.394046,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 27.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 102 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/examples/presentar_demo.rs": {
+      "content_hash": [
+        228,
+        113,
+        165,
+        214,
+        17,
+        157,
+        3,
+        125,
+        24,
+        242,
+        166,
+        87,
+        25,
+        207,
+        204,
+        78,
+        92,
+        40,
+        205,
+        102,
+        62,
+        221,
+        27,
+        154,
+        144,
+        127,
+        170,
+        74,
+        101,
+        166,
+        223,
+        72
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/examples/presentar_demo.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/histogram.rs": {
+      "content_hash": [
+        69,
+        149,
+        177,
+        125,
+        84,
+        64,
+        124,
+        5,
+        69,
+        63,
+        8,
+        148,
+        180,
+        239,
+        239,
+        115,
+        179,
+        28,
+        167,
+        239,
+        28,
+        193,
+        116,
+        30,
+        29,
+        160,
+        102,
+        197,
+        82,
+        129,
+        233,
+        182
+      ],
+      "score": {
+        "structural_complexity": 24.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.93811,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.85283,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/histogram.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.90000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 18"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0618892,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.3%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 22 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/searchindex.js": {
+      "content_hash": [
+        104,
+        215,
+        75,
+        187,
+        244,
+        102,
+        145,
+        120,
+        204,
+        10,
+        224,
+        211,
+        173,
+        103,
+        19,
+        45,
+        14,
+        88,
+        154,
+        150,
+        52,
+        26,
+        210,
+        185,
+        26,
+        47,
+        161,
+        237,
+        242,
+        75,
+        30,
+        21
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/searchindex.js",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/test_macos_collectors.rs": {
+      "content_hash": [
+        89,
+        8,
+        85,
+        217,
+        219,
+        201,
+        112,
+        34,
+        239,
+        118,
+        66,
+        58,
+        47,
+        98,
+        136,
+        13,
+        251,
+        226,
+        169,
+        107,
+        134,
+        186,
+        8,
+        206,
+        212,
+        141,
+        96,
+        180,
+        102,
+        99,
+        231,
+        250
+      ],
+      "score": {
+        "structural_complexity": 24.1,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 97.36363,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/test_macos_collectors.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.90000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 18"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./pkg/trueno_viz_bg.wasm.d.ts": {
+      "content_hash": [
+        54,
+        217,
+        19,
+        205,
+        64,
+        253,
+        5,
+        124,
+        162,
+        110,
+        32,
+        30,
+        47,
+        249,
+        3,
+        89,
+        214,
+        196,
+        57,
+        185,
+        63,
+        84,
+        34,
+        171,
+        100,
+        251,
+        144,
+        68,
+        57,
+        129,
+        182,
+        85
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./pkg/trueno_viz_bg.wasm.d.ts",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/proptest_macos.rs": {
+      "content_hash": [
+        239,
+        73,
+        43,
+        19,
+        192,
+        93,
+        25,
+        82,
+        181,
+        107,
+        134,
+        70,
+        238,
+        19,
+        207,
+        12,
+        237,
+        234,
+        46,
+        127,
+        197,
+        251,
+        69,
+        108,
+        2,
+        80,
+        145,
+        152,
+        23,
+        42,
+        142,
+        156
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.798817,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.635284,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/proptest_macos.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.2011833,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 21.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 25 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/interop/trueno_graph.rs": {
+      "content_hash": [
+        111,
+        198,
+        14,
+        209,
+        119,
+        116,
+        204,
+        86,
+        0,
+        33,
+        226,
+        134,
+        70,
+        86,
+        250,
+        252,
+        74,
+        99,
+        191,
+        111,
+        117,
+        253,
+        21,
+        26,
+        61,
+        248,
+        147,
+        235,
+        25,
+        97,
+        186,
+        254
+      ],
+      "score": {
+        "structural_complexity": 22.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.954955,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.954956,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/interop/trueno_graph.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 25"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 42 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.045045,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 25.2%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/gpu_amd.rs": {
+      "content_hash": [
+        210,
+        229,
+        118,
+        30,
+        59,
+        235,
+        42,
+        169,
+        25,
+        181,
+        156,
+        202,
+        178,
+        24,
+        224,
+        110,
+        57,
+        76,
+        47,
+        97,
+        144,
+        185,
+        209,
+        84,
+        226,
+        89,
+        231,
+        57,
+        100,
+        121,
+        180,
+        165
+      ],
+      "score": {
+        "structural_complexity": 21.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.454544,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/gpu_amd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 22 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.3000002,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 26"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/error.rs": {
+      "content_hash": [
+        18,
+        7,
+        175,
+        226,
+        71,
+        134,
+        175,
+        118,
+        202,
+        163,
+        165,
+        176,
+        127,
+        50,
+        78,
+        198,
+        45,
+        132,
+        149,
+        223,
+        124,
+        116,
+        197,
+        193,
+        156,
+        178,
+        20,
+        158,
+        21,
+        255,
+        193,
+        49
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.0,
+        "total": 96.36363,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/error.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 8 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/stat.rs": {
+      "content_hash": [
+        76,
+        18,
+        45,
+        94,
+        117,
+        122,
+        204,
+        82,
+        116,
+        153,
+        68,
+        253,
+        188,
+        219,
+        4,
+        109,
+        51,
+        113,
+        61,
+        222,
+        241,
+        184,
+        87,
+        250,
+        197,
+        50,
+        229,
+        112,
+        31,
+        83,
+        133,
+        75
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/stat.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/toc.js": {
+      "content_hash": [
+        105,
+        104,
+        106,
+        145,
+        75,
+        28,
+        63,
+        114,
+        102,
+        236,
+        233,
+        21,
+        145,
+        130,
+        97,
+        113,
+        26,
+        210,
+        181,
+        194,
+        10,
+        18,
+        19,
+        180,
+        199,
+        141,
+        122,
+        104,
+        157,
+        213,
+        137,
+        254
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/toc.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/output/svg.rs": {
+      "content_hash": [
+        51,
+        37,
+        137,
+        160,
+        136,
+        238,
+        214,
+        146,
+        46,
+        146,
+        18,
+        64,
+        22,
+        234,
+        231,
+        139,
+        27,
+        21,
+        221,
+        129,
+        231,
+        30,
+        56,
+        62,
+        249,
+        29,
+        83,
+        124,
+        247,
+        228,
+        48,
+        152
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.898954,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.635414,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/output/svg.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 62 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1010451,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/input.rs": {
+      "content_hash": [
+        164,
+        105,
+        182,
+        181,
+        90,
+        187,
+        87,
+        245,
+        221,
+        148,
+        170,
+        132,
+        212,
+        72,
+        94,
+        103,
+        2,
+        244,
+        164,
+        181,
+        156,
+        252,
+        128,
+        135,
+        241,
+        81,
+        124,
+        222,
+        210,
+        46,
+        84,
+        143
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/input.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/gpu_simd.rs": {
+      "content_hash": [
+        250,
+        39,
+        183,
+        25,
+        165,
+        247,
+        251,
+        105,
+        96,
+        85,
+        209,
+        165,
+        111,
+        154,
+        4,
+        211,
+        121,
+        144,
+        19,
+        181,
+        242,
+        216,
+        33,
+        243,
+        213,
+        128,
+        34,
+        107,
+        151,
+        93,
+        91,
+        135
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.594936,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.26813,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/gpu_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.4050634,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.0%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/mod.rs": {
+      "content_hash": [
+        33,
+        227,
+        205,
+        78,
+        134,
+        119,
+        62,
+        32,
+        1,
+        20,
+        89,
+        191,
+        44,
+        208,
+        234,
+        75,
+        187,
+        122,
+        99,
+        237,
+        243,
+        88,
+        177,
+        124,
+        10,
+        230,
+        203,
+        125,
+        111,
+        204,
+        197,
+        241
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/horizon.rs": {
+      "content_hash": [
+        222,
+        203,
+        247,
+        106,
+        230,
+        78,
+        233,
+        19,
+        46,
+        158,
+        21,
+        11,
+        14,
+        247,
+        43,
+        138,
+        216,
+        72,
+        112,
+        7,
+        189,
+        61,
+        99,
+        87,
+        160,
+        177,
+        203,
+        171,
+        32,
+        135,
+        236,
+        55
+      ],
+      "score": {
+        "structural_complexity": 14.2,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.01818,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.218185,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/horizon.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 37 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 36"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 7.8,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 41"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.9818182,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.9%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/ffi/mod.rs": {
+      "content_hash": [
+        117,
+        73,
+        86,
+        108,
+        35,
+        80,
+        5,
+        87,
+        67,
+        1,
+        80,
+        97,
+        173,
+        38,
+        131,
+        243,
+        145,
+        214,
+        194,
+        189,
+        142,
+        60,
+        237,
+        63,
+        31,
+        24,
+        183,
+        168,
+        233,
+        17,
+        131,
+        134
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.5,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 97.27273,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/ffi/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/ring_buffer.rs": {
+      "content_hash": [
+        173,
+        69,
+        157,
+        78,
+        249,
+        182,
+        153,
+        116,
+        124,
+        187,
+        162,
+        20,
+        161,
+        142,
+        96,
+        141,
+        173,
+        219,
+        41,
+        99,
+        34,
+        176,
+        215,
+        127,
+        188,
+        10,
+        18,
+        115,
+        113,
+        234,
+        75,
+        108
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.685083,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.44098,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/ring_buffer.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.314917,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.6%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 33 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/theme.rs": {
+      "content_hash": [
+        169,
+        188,
+        79,
+        241,
+        160,
+        49,
+        215,
+        42,
+        5,
+        52,
+        14,
+        189,
+        16,
+        81,
+        206,
+        7,
+        87,
+        247,
+        116,
+        27,
+        87,
+        72,
+        219,
+        146,
+        9,
+        155,
+        203,
+        58,
+        13,
+        12,
+        136,
+        6
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.785124,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.62284,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/theme.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 23 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.214876,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 21.1%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/tests/falsification_tests.rs": {
+      "content_hash": [
+        122,
+        74,
+        21,
+        195,
+        7,
+        39,
+        68,
+        5,
+        144,
+        84,
+        108,
+        222,
+        2,
+        182,
+        125,
+        128,
+        46,
+        39,
+        148,
+        203,
+        31,
+        88,
+        106,
+        101,
+        103,
+        125,
+        245,
+        224,
+        31,
+        106,
+        72,
+        67
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/tests/falsification_tests.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 24 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/lib.rs": {
+      "content_hash": [
+        32,
+        119,
+        95,
+        64,
+        219,
+        154,
+        162,
+        240,
+        55,
+        2,
+        43,
+        210,
+        146,
+        217,
+        26,
+        161,
+        118,
+        199,
+        7,
+        147,
+        128,
+        179,
+        176,
+        153,
+        194,
+        57,
+        84,
+        136,
+        49,
+        50,
+        13,
+        72
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/lib.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/output/mod.rs": {
+      "content_hash": [
+        192,
+        47,
+        248,
+        82,
+        97,
+        33,
+        194,
+        234,
+        161,
+        156,
+        166,
+        211,
+        43,
+        253,
+        221,
+        0,
+        251,
+        89,
+        112,
+        13,
+        204,
+        163,
+        254,
+        139,
+        237,
+        13,
+        214,
+        18,
+        8,
+        255,
+        225,
+        154
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/output/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/mod.rs": {
+      "content_hash": [
+        149,
+        30,
+        236,
+        238,
+        93,
+        233,
+        34,
+        42,
+        27,
+        248,
+        40,
+        137,
+        163,
+        245,
+        225,
+        63,
+        166,
+        181,
+        123,
+        46,
+        221,
+        101,
+        224,
+        30,
+        6,
+        50,
+        178,
+        227,
+        72,
+        136,
+        15,
+        149
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/sensors.rs": {
+      "content_hash": [
+        224,
+        76,
+        215,
+        3,
+        178,
+        204,
+        197,
+        132,
+        243,
+        40,
+        245,
+        100,
+        103,
+        180,
+        129,
+        53,
+        228,
+        14,
+        191,
+        196,
+        27,
+        224,
+        24,
+        217,
+        57,
+        219,
+        142,
+        141,
+        164,
+        239,
+        33,
+        161
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.150839,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.8644,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/sensors.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.8491619,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 30 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/layout.rs": {
+      "content_hash": [
+        231,
+        166,
+        14,
+        192,
+        138,
+        82,
+        194,
+        27,
+        81,
+        191,
+        66,
+        70,
+        185,
+        222,
+        11,
+        247,
+        45,
+        195,
+        210,
+        31,
+        99,
+        211,
+        24,
+        66,
+        150,
+        251,
+        117,
+        146,
+        251,
+        41,
+        120,
+        135
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.869823,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.51803,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/layout.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.1301775,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 17 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/pkg/trueno_viz_wasm.d.ts": {
+      "content_hash": [
+        181,
+        121,
+        73,
+        150,
+        13,
+        21,
+        116,
+        198,
+        153,
+        8,
+        15,
+        103,
+        219,
+        122,
+        252,
+        20,
+        154,
+        61,
+        119,
+        93,
+        153,
+        30,
+        149,
+        34,
+        119,
+        49,
+        253,
+        140,
+        197,
+        103,
+        235,
+        206
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm.d.ts",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./wasm-pkg/playwright.config.ts": {
+      "content_hash": [
+        18,
+        134,
+        36,
+        31,
+        84,
+        164,
+        22,
+        249,
+        82,
+        10,
+        201,
+        212,
+        104,
+        27,
+        171,
+        168,
+        229,
+        206,
+        239,
+        108,
+        119,
+        119,
+        140,
+        88,
+        18,
+        158,
+        51,
+        79,
+        54,
+        109,
+        38,
+        14
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "TypeScript",
+        "file_path": "./wasm-pkg/playwright.config.ts",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./tests/pixel_verification_test.rs": {
+      "content_hash": [
+        18,
+        98,
+        20,
+        87,
+        77,
+        123,
+        229,
+        81,
+        233,
+        81,
+        238,
+        87,
+        202,
+        49,
+        63,
+        242,
+        24,
+        119,
+        41,
+        114,
+        128,
+        46,
+        88,
+        224,
+        34,
+        211,
+        188,
+        31,
+        120,
+        93,
+        133,
+        198
+      ],
+      "score": {
+        "structural_complexity": 18.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.922865,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 94.32287,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./tests/pixel_verification_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.077135,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 20.4%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 33 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.6000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 37"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./tests/popperian_falsification_test.rs": {
+      "content_hash": [
+        103,
+        45,
+        38,
+        90,
+        221,
+        69,
+        152,
+        196,
+        244,
+        126,
+        40,
+        192,
+        30,
+        207,
+        77,
+        38,
+        211,
+        17,
+        232,
+        231,
+        198,
+        181,
+        213,
+        246,
+        181,
+        6,
+        194,
+        90,
+        206,
+        153,
+        191,
+        247
+      ],
+      "score": {
+        "structural_complexity": 9.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.816619,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 85.31662,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./tests/popperian_falsification_test.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 85 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 43"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.183381,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 20.9%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 45"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/prompt/mod.rs": {
+      "content_hash": [
+        93,
+        221,
+        26,
+        236,
+        154,
+        16,
+        86,
+        139,
+        86,
+        246,
+        161,
+        172,
+        48,
+        232,
+        207,
+        132,
+        42,
+        50,
+        20,
+        35,
+        99,
+        195,
+        179,
+        131,
+        123,
+        101,
+        42,
+        234,
+        142,
+        188,
+        89,
+        162
+      ],
+      "score": {
+        "structural_complexity": 1.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.75,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 78.75,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/prompt/mod.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 13.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 56"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 45"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.25,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 27 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/soa.rs": {
+      "content_hash": [
+        190,
+        11,
+        75,
+        133,
+        4,
+        164,
+        15,
+        32,
+        122,
+        202,
+        187,
+        69,
+        127,
+        39,
+        202,
+        160,
+        64,
+        2,
+        22,
+        115,
+        209,
+        53,
+        107,
+        36,
+        244,
+        243,
+        13,
+        113,
+        123,
+        83,
+        206,
+        215
+      ],
+      "score": {
+        "structural_complexity": 21.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.95539,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.35539,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/soa.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.6000001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 27"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0446095,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 32 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/bin/debug_disk.rs": {
+      "content_hash": [
+        40,
+        102,
+        146,
+        143,
+        141,
+        223,
+        204,
+        96,
+        172,
+        158,
+        119,
+        190,
+        39,
+        95,
+        241,
+        166,
+        96,
+        109,
+        196,
+        204,
+        58,
+        158,
+        218,
+        85,
+        155,
+        150,
+        79,
+        127,
+        41,
+        245,
+        135,
+        218
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.0,
+        "total": 98.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/bin/debug_disk.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 4 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/widgets/experiment/run_table.rs": {
+      "content_hash": [
+        240,
+        217,
+        77,
+        129,
+        113,
+        75,
+        137,
+        208,
+        23,
+        135,
+        180,
+        162,
+        167,
+        54,
+        25,
+        90,
+        9,
+        228,
+        28,
+        168,
+        124,
+        43,
+        45,
+        5,
+        12,
+        30,
+        89,
+        25,
+        124,
+        57,
+        219,
+        219
+      ],
+      "score": {
+        "structural_complexity": 22.3,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.505112,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.805115,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/widgets/experiment/run_table.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 34 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.4948876,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.5%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 33"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.2,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 19"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/render/primitives.rs": {
+      "content_hash": [
+        166,
+        84,
+        122,
+        152,
+        37,
+        178,
+        120,
+        40,
+        167,
+        171,
+        98,
+        34,
+        199,
+        161,
+        226,
+        146,
+        39,
+        200,
+        252,
+        53,
+        201,
+        5,
+        63,
+        170,
+        177,
+        157,
+        44,
+        24,
+        228,
+        143,
+        184,
+        255
+      ],
+      "score": {
+        "structural_complexity": 16.8,
+        "semantic_complexity": 19.0,
+        "duplication_ratio": 17.103064,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.90306,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/render/primitives.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.896936,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.5%"
+          },
+          {
+            "source_metric": "SemanticComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "SemanticComplexity"
+            ],
+            "issue": "Too many parameters: 7"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 35 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 32"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 7.2000003,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 39"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/mod.rs": {
+      "content_hash": [
+        38,
+        169,
+        61,
+        87,
+        80,
+        23,
+        47,
+        191,
+        74,
+        226,
+        44,
+        163,
+        164,
+        241,
+        210,
+        182,
+        112,
+        86,
+        211,
+        86,
+        15,
+        81,
+        227,
+        173,
+        187,
+        215,
+        50,
+        175,
+        46,
+        33,
+        76,
+        112
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/mod.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/file_analyzer.rs": {
+      "content_hash": [
+        179,
+        134,
+        5,
+        180,
+        77,
+        156,
+        171,
+        37,
+        95,
+        19,
+        212,
+        2,
+        167,
+        119,
+        5,
+        40,
+        201,
+        220,
+        27,
+        131,
+        124,
+        141,
+        6,
+        160,
+        210,
+        55,
+        182,
+        236,
+        159,
+        41,
+        119,
+        6
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 80.0,
+        "grade": "BPlus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/file_analyzer.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 98"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 48 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 122"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/panels/disk_network.rs": {
+      "content_hash": [
+        0,
+        169,
+        44,
+        84,
+        78,
+        147,
+        9,
+        76,
+        2,
+        168,
+        203,
+        172,
+        195,
+        202,
+        246,
+        109,
+        129,
+        76,
+        165,
+        218,
+        99,
+        96,
+        21,
+        236,
+        51,
+        136,
+        39,
+        4,
+        232,
+        171,
+        122,
+        14
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 19.0,
+        "duplication_ratio": 17.9676,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 76.9676,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/panels/disk_network.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "SemanticComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "SemanticComplexity"
+            ],
+            "issue": "Too many parameters: 7"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 176"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 54 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0324006,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.2%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 128"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/ring_buffer.rs": {
+      "content_hash": [
+        111,
+        237,
+        150,
+        30,
+        4,
+        170,
+        94,
+        118,
+        81,
+        26,
+        2,
+        218,
+        55,
+        71,
+        28,
+        236,
+        223,
+        55,
+        237,
+        89,
+        242,
+        43,
+        228,
+        116,
+        34,
+        130,
+        195,
+        95,
+        132,
+        1,
+        216,
+        105
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.869566,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.608696,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/ring_buffer.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1304348,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 43 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/geom.rs": {
+      "content_hash": [
+        146,
+        67,
+        129,
+        162,
+        146,
+        135,
+        204,
+        154,
+        56,
+        128,
+        242,
+        175,
+        65,
+        158,
+        146,
+        157,
+        213,
+        153,
+        130,
+        247,
+        42,
+        244,
+        111,
+        154,
+        241,
+        138,
+        198,
+        58,
+        10,
+        86,
+        164,
+        114
+      ],
+      "score": {
+        "structural_complexity": 17.8,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.487684,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.28768,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/geom.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 4.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 39"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5123153,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.6%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.7,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 24"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 28 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/terminal_output.rs": {
+      "content_hash": [
+        121,
+        155,
+        111,
+        179,
+        13,
+        143,
+        90,
+        249,
+        155,
+        92,
+        33,
+        67,
+        247,
+        146,
+        86,
+        150,
+        1,
+        251,
+        229,
+        251,
+        207,
+        153,
+        208,
+        215,
+        167,
+        205,
+        114,
+        10,
+        46,
+        107,
+        69,
+        66
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/terminal_output.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/roc_pr_curves.rs": {
+      "content_hash": [
+        106,
+        13,
+        73,
+        177,
+        123,
+        64,
+        156,
+        177,
+        213,
+        211,
+        237,
+        167,
+        150,
+        205,
+        25,
+        43,
+        87,
+        36,
+        234,
+        228,
+        10,
+        133,
+        186,
+        176,
+        188,
+        225,
+        11,
+        72,
+        77,
+        122,
+        79,
+        60
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/roc_pr_curves.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/memory_simd.rs": {
+      "content_hash": [
+        135,
+        241,
+        52,
+        73,
+        36,
+        233,
+        163,
+        89,
+        212,
+        251,
+        29,
+        193,
+        177,
+        210,
+        100,
+        225,
+        230,
+        94,
+        213,
+        89,
+        103,
+        13,
+        168,
+        39,
+        118,
+        124,
+        136,
+        1,
+        144,
+        131,
+        25,
+        1
+      ],
+      "score": {
+        "structural_complexity": 10.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 90.0,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/memory_simd.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 11 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 13 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 68"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/remote.rs": {
+      "content_hash": [
+        94,
+        123,
+        230,
+        171,
+        176,
+        246,
+        98,
+        30,
+        124,
+        205,
+        2,
+        103,
+        37,
+        163,
+        186,
+        242,
+        41,
+        12,
+        63,
+        78,
+        194,
+        29,
+        5,
+        72,
+        25,
+        22,
+        138,
+        27,
+        221,
+        238,
+        61,
+        160
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/remote.rs",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/plots/loss_curve.rs": {
+      "content_hash": [
+        56,
+        209,
+        240,
+        26,
+        94,
+        114,
+        34,
+        137,
+        92,
+        84,
+        116,
+        172,
+        235,
+        125,
+        42,
+        10,
+        69,
+        220,
+        63,
+        169,
+        37,
+        207,
+        4,
+        174,
+        155,
+        34,
+        200,
+        225,
+        177,
+        9,
+        159,
+        217
+      ],
+      "score": {
+        "structural_complexity": 12.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.718147,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 88.71815,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/plots/loss_curve.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 3.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 7 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 38 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.2818532,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.4%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 54"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/types.rs": {
+      "content_hash": [
+        141,
+        247,
+        52,
+        104,
+        19,
+        38,
+        101,
+        167,
+        25,
+        68,
+        153,
+        203,
+        41,
+        24,
+        89,
+        65,
+        126,
+        224,
+        164,
+        2,
+        58,
+        230,
+        121,
+        51,
+        63,
+        110,
+        52,
+        213,
+        202,
+        82,
+        30,
+        229
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/types.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/app/tests.rs": {
+      "content_hash": [
+        55,
+        172,
+        102,
+        180,
+        113,
+        97,
+        152,
+        191,
+        42,
+        144,
+        161,
+        156,
+        64,
+        244,
+        188,
+        40,
+        215,
+        96,
+        177,
+        44,
+        75,
+        164,
+        200,
+        57,
+        199,
+        177,
+        132,
+        231,
+        128,
+        11,
+        46,
+        95
+      ],
+      "score": {
+        "structural_complexity": 19.3,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.655415,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.955414,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/app/tests.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.3445854,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 26.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 95 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.7000003,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 34"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/gauge.rs": {
+      "content_hash": [
+        231,
+        113,
+        65,
+        201,
+        92,
+        234,
+        233,
+        44,
+        62,
+        116,
+        98,
+        82,
+        183,
+        202,
+        153,
+        6,
+        196,
+        13,
+        74,
+        240,
+        7,
+        175,
+        45,
+        4,
+        71,
+        20,
+        0,
+        106,
+        30,
+        6,
+        198,
+        74
+      ],
+      "score": {
+        "structural_complexity": 18.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.659039,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.05904,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/gauge.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.6000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 37"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.340961,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.7%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 34 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/searcher.js": {
+      "content_hash": [
+        183,
+        88,
+        191,
+        155,
+        45,
+        157,
+        186,
+        140,
+        59,
+        165,
+        253,
+        192,
+        3,
+        249,
+        95,
+        175,
+        206,
+        28,
+        59,
+        93,
+        218,
+        57,
+        8,
+        29,
+        217,
+        173,
+        167,
+        112,
+        32,
+        251,
+        189,
+        161
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/searcher.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 5.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent quote usage detected"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 21 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./examples/force_graph.rs": {
+      "content_hash": [
+        156,
+        94,
+        90,
+        151,
+        96,
+        234,
+        64,
+        17,
+        253,
+        166,
+        240,
+        133,
+        229,
+        216,
+        107,
+        104,
+        164,
+        105,
+        67,
+        195,
+        204,
+        7,
+        197,
+        105,
+        203,
+        193,
+        103,
+        144,
+        55,
+        171,
+        54,
+        248
+      ],
+      "score": {
+        "structural_complexity": 24.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.18182,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./examples/force_graph.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 0.6,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 17"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/treemap.rs": {
+      "content_hash": [
+        98,
+        95,
+        190,
+        170,
+        248,
+        112,
+        229,
+        54,
+        176,
+        16,
+        149,
+        200,
+        132,
+        228,
+        119,
+        202,
+        183,
+        183,
+        59,
+        68,
+        139,
+        4,
+        46,
+        137,
+        86,
+        168,
+        188,
+        53,
+        86,
+        141,
+        156,
+        107
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.67426,
+        "coupling_score": 14.2,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 75.87426,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/treemap.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 77"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.3257403,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.6%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 89 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 106"
+          },
+          {
+            "source_metric": "Coupling",
+            "amount": 0.8,
+            "applied_to": [
+              "Coupling"
+            ],
+            "issue": "Too many imports: 24"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/error.rs": {
+      "content_hash": [
+        161,
+        150,
+        207,
+        170,
+        65,
+        102,
+        37,
+        190,
+        21,
+        122,
+        7,
+        27,
+        88,
+        21,
+        110,
+        244,
+        71,
+        243,
+        161,
+        76,
+        108,
+        89,
+        88,
+        90,
+        254,
+        102,
+        68,
+        81,
+        39,
+        104,
+        70,
+        76
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/error.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 3 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/editor.js": {
+      "content_hash": [
+        57,
+        158,
+        36,
+        233,
+        200,
+        189,
+        195,
+        102,
+        23,
+        20,
+        192,
+        90,
+        134,
+        111,
+        215,
+        84,
+        116,
+        108,
+        50,
+        173,
+        223,
+        210,
+        255,
+        249,
+        3,
+        112,
+        16,
+        236,
+        239,
+        196,
+        21,
+        6
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/editor.js",
+        "penalties_applied": [
+          {
+            "source_metric": "Consistency",
+            "amount": 10.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent semicolon usage detected"
+          },
+          {
+            "source_metric": "Consistency",
+            "amount": 5.0,
+            "applied_to": [
+              "Consistency"
+            ],
+            "issue": "Inconsistent quote usage detected"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/highlight.js": {
+      "content_hash": [
+        94,
+        247,
+        88,
+        103,
+        10,
+        83,
+        7,
+        55,
+        108,
+        239,
+        9,
+        38,
+        56,
+        59,
+        174,
+        9,
+        247,
+        29,
+        91,
+        61,
+        120,
+        251,
+        116,
+        41,
+        88,
+        210,
+        224,
+        97,
+        254,
+        38,
+        205,
+        129
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/highlight.js",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/panels/process.rs": {
+      "content_hash": [
+        115,
+        26,
+        59,
+        116,
+        217,
+        56,
+        201,
+        115,
+        190,
+        109,
+        32,
+        45,
+        140,
+        32,
+        51,
+        16,
+        113,
+        75,
+        165,
+        6,
+        133,
+        0,
+        167,
+        13,
+        202,
+        133,
+        24,
+        148,
+        185,
+        91,
+        165,
+        128
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/panels/process.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/table.rs": {
+      "content_hash": [
+        177,
+        133,
+        168,
+        51,
+        202,
+        41,
+        136,
+        31,
+        255,
+        214,
+        183,
+        93,
+        207,
+        74,
+        182,
+        104,
+        110,
+        28,
+        52,
+        94,
+        39,
+        7,
+        172,
+        208,
+        237,
+        78,
+        141,
+        56,
+        17,
+        182,
+        95,
+        214
+      ],
+      "score": {
+        "structural_complexity": 18.4,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.763285,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 95.163284,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/table.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 6.6000004,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 37"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.2367148,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.2%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 40 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/simd/integration_tests.rs": {
+      "content_hash": [
+        51,
+        60,
+        12,
+        82,
+        153,
+        139,
+        54,
+        59,
+        34,
+        239,
+        223,
+        92,
+        60,
+        89,
+        57,
+        95,
+        113,
+        253,
+        70,
+        64,
+        22,
+        68,
+        87,
+        122,
+        172,
+        126,
+        224,
+        93,
+        110,
+        201,
+        184,
+        57
+      ],
+      "score": {
+        "structural_complexity": 14.7,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.343452,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 92.04346,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/simd/integration_tests.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 35"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 7.8,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 41"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.6565466,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 13.3%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 46 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/geoip.rs": {
+      "content_hash": [
+        12,
+        120,
+        167,
+        76,
+        69,
+        50,
+        204,
+        40,
+        136,
+        175,
+        72,
+        92,
+        236,
+        157,
+        98,
+        210,
+        215,
+        20,
+        230,
+        67,
+        255,
+        28,
+        12,
+        146,
+        60,
+        28,
+        247,
+        183,
+        148,
+        252,
+        153,
+        62
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.0,
+        "total": 97.27273,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/geoip.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 6 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./book/book/mark.min.js": {
+      "content_hash": [
+        0,
+        169,
+        162,
+        32,
+        56,
+        176,
+        242,
+        242,
+        218,
+        114,
+        99,
+        170,
+        136,
+        103,
+        209,
+        11,
+        165,
+        147,
+        75,
+        232,
+        210,
+        178,
+        180,
+        177,
+        14,
+        218,
+        40,
+        77,
+        0,
+        239,
+        126,
+        137
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 10.0,
+        "total": 100.0,
+        "grade": "APLus",
+        "confidence": 0.9,
+        "language": "JavaScript",
+        "file_path": "./book/book/mark.min.js",
+        "penalties_applied": [],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./crates/ttop/src/analyzers/connections.rs": {
+      "content_hash": [
+        212,
+        208,
+        33,
+        112,
+        115,
+        2,
+        139,
+        28,
+        231,
+        117,
+        189,
+        69,
+        173,
+        248,
+        206,
+        190,
+        128,
+        95,
+        12,
+        219,
+        243,
+        12,
+        210,
+        10,
+        243,
+        127,
+        108,
+        110,
+        112,
+        172,
+        159,
+        34
+      ],
+      "score": {
+        "structural_complexity": 0.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.38397,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 76.38397,
+        "grade": "B",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./crates/ttop/src/analyzers/connections.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 67 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.61603,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 18.1%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 96"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 136"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/widgets/experiment/sparkline.rs": {
+      "content_hash": [
+        202,
+        217,
+        228,
+        223,
+        118,
+        132,
+        89,
+        255,
+        248,
+        93,
+        83,
+        67,
+        23,
+        162,
+        190,
+        19,
+        36,
+        107,
+        160,
+        46,
+        129,
+        219,
+        192,
+        64,
+        182,
+        162,
+        149,
+        190,
+        166,
+        225,
+        246,
+        10
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.805908,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 93.459915,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/widgets/experiment/sparkline.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.1940928,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 11.0%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./benches/scatter_benchmark.rs": {
+      "content_hash": [
+        167,
+        6,
+        69,
+        156,
+        102,
+        135,
+        99,
+        29,
+        240,
+        245,
+        231,
+        225,
+        77,
+        176,
+        24,
+        50,
+        128,
+        214,
+        151,
+        166,
+        48,
+        40,
+        40,
+        107,
+        115,
+        91,
+        36,
+        125,
+        44,
+        92,
+        16,
+        120
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./benches/scatter_benchmark.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 1.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 2 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/memory.rs": {
+      "content_hash": [
+        101,
+        13,
+        253,
+        170,
+        165,
+        215,
+        250,
+        206,
+        33,
+        143,
+        185,
+        146,
+        41,
+        22,
+        164,
+        112,
+        155,
+        2,
+        48,
+        217,
+        186,
+        159,
+        235,
+        241,
+        245,
+        98,
+        233,
+        8,
+        71,
+        252,
+        50,
+        204
+      ],
+      "score": {
+        "structural_complexity": 10.599999,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.806084,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 87.40608,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/memory.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.900001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 48"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.1939163,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.0%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 35"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 6 levels"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 42 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/grammar/ggplot.rs": {
+      "content_hash": [
+        34,
+        79,
+        149,
+        242,
+        64,
+        235,
+        248,
+        140,
+        13,
+        90,
+        71,
+        132,
+        173,
+        40,
+        197,
+        111,
+        57,
+        162,
+        4,
+        3,
+        203,
+        38,
+        119,
+        223,
+        130,
+        185,
+        137,
+        5,
+        20,
+        199,
+        114,
+        16
+      ],
+      "score": {
+        "structural_complexity": 8.5,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.040872,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 83.54087,
+        "grade": "BPlus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/grammar/ggplot.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 4.9591284,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 24.8%"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.5,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 41"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 10.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 55"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 64 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 1.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "Deep nesting: 5 levels"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/widgets/sparkline.rs": {
+      "content_hash": [
+        14,
+        128,
+        37,
+        61,
+        229,
+        206,
+        170,
+        90,
+        156,
+        38,
+        100,
+        20,
+        203,
+        102,
+        155,
+        133,
+        166,
+        80,
+        233,
+        76,
+        88,
+        170,
+        103,
+        56,
+        133,
+        207,
+        124,
+        220,
+        231,
+        237,
+        75,
+        250
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 14.628975,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 99.628975,
+        "grade": "APLus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/widgets/sparkline.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.3710246,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 26.9%"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 29 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/monitor/collectors/disk.rs": {
+      "content_hash": [
+        74,
+        102,
+        83,
+        177,
+        80,
+        88,
+        103,
+        196,
+        180,
+        139,
+        83,
+        65,
+        79,
+        160,
+        114,
+        175,
+        169,
+        222,
+        25,
+        193,
+        155,
+        199,
+        86,
+        26,
+        195,
+        165,
+        156,
+        197,
+        254,
+        140,
+        78,
+        77
+      ],
+      "score": {
+        "structural_complexity": 10.099999,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.54816,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 87.64816,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/monitor/collectors/disk.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 9.900001,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 48"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 54 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 5.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 40"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.451839,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 12.3%"
           }
         ],
         "critical_defects_count": 0,
@@ -408,15476 +15862,22 @@
         "consistency_violations": []
       },
       "git_context": null
-    },
-    "./src/monitor/panels/cpu.rs": {
-      "content_hash": [
-        98,
-        163,
-        147,
-        163,
-        137,
-        189,
-        231,
-        167,
-        142,
-        43,
-        92,
-        59,
-        209,
-        193,
-        152,
-        161,
-        171,
-        155,
-        96,
-        227,
-        34,
-        53,
-        215,
-        185,
-        173,
-        52,
-        207,
-        175,
-        202,
-        121,
-        210,
-        253
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 98.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/cpu.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/scatter_benchmark.rs": {
-      "content_hash": [
-        167,
-        6,
-        69,
-        156,
-        102,
-        135,
-        99,
-        29,
-        240,
-        245,
-        231,
-        225,
-        77,
-        176,
-        24,
-        50,
-        128,
-        214,
-        151,
-        166,
-        48,
-        40,
-        40,
-        107,
-        115,
-        91,
-        36,
-        125,
-        44,
-        92,
-        16,
-        120
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/scatter_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/panels/mod.rs": {
-      "content_hash": [
-        64,
-        130,
-        33,
-        168,
-        168,
-        56,
-        165,
-        126,
-        72,
-        248,
-        152,
-        244,
-        159,
-        33,
-        181,
-        248,
-        253,
-        47,
-        181,
-        125,
-        195,
-        121,
-        180,
-        222,
-        122,
-        73,
-        21,
-        72,
-        193,
-        249,
-        17,
-        192
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/remote.rs": {
-      "content_hash": [
-        94,
-        123,
-        230,
-        171,
-        176,
-        246,
-        98,
-        30,
-        124,
-        205,
-        2,
-        103,
-        37,
-        163,
-        186,
-        242,
-        41,
-        12,
-        63,
-        78,
-        194,
-        29,
-        5,
-        72,
-        25,
-        22,
-        138,
-        27,
-        221,
-        238,
-        61,
-        160
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/remote.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/mod.rs": {
-      "content_hash": [
-        38,
-        169,
-        61,
-        87,
-        80,
-        23,
-        47,
-        191,
-        74,
-        226,
-        44,
-        163,
-        164,
-        241,
-        210,
-        182,
-        112,
-        86,
-        211,
-        86,
-        15,
-        81,
-        227,
-        173,
-        187,
-        215,
-        50,
-        175,
-        46,
-        33,
-        76,
-        112
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./tests/pixel_verification_test.rs": {
-      "content_hash": [
-        18,
-        98,
-        20,
-        87,
-        77,
-        123,
-        229,
-        81,
-        233,
-        81,
-        238,
-        87,
-        202,
-        49,
-        63,
-        242,
-        24,
-        119,
-        41,
-        114,
-        128,
-        46,
-        88,
-        224,
-        34,
-        211,
-        188,
-        31,
-        120,
-        93,
-        133,
-        198
-      ],
-      "score": {
-        "structural_complexity": 18.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.922865,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.32287,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./tests/pixel_verification_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 33 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.6000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 37"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.077135,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 20.4%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/stat.rs": {
-      "content_hash": [
-        76,
-        18,
-        45,
-        94,
-        117,
-        122,
-        204,
-        82,
-        116,
-        153,
-        68,
-        253,
-        188,
-        219,
-        4,
-        109,
-        51,
-        113,
-        61,
-        222,
-        241,
-        184,
-        87,
-        250,
-        197,
-        50,
-        229,
-        112,
-        31,
-        83,
-        133,
-        75
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.72727,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/stat.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./pkg/trueno_viz_bg.wasm.d.ts": {
-      "content_hash": [
-        54,
-        217,
-        19,
-        205,
-        64,
-        253,
-        5,
-        124,
-        162,
-        110,
-        32,
-        30,
-        47,
-        249,
-        3,
-        89,
-        214,
-        196,
-        57,
-        185,
-        63,
-        84,
-        34,
-        171,
-        100,
-        251,
-        144,
-        68,
-        57,
-        129,
-        182,
-        85
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./pkg/trueno_viz_bg.wasm.d.ts",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/test_macos_collectors.rs": {
-      "content_hash": [
-        89,
-        8,
-        85,
-        217,
-        219,
-        201,
-        112,
-        34,
-        239,
-        118,
-        66,
-        58,
-        47,
-        98,
-        136,
-        13,
-        251,
-        226,
-        169,
-        107,
-        134,
-        186,
-        8,
-        206,
-        212,
-        141,
-        96,
-        180,
-        102,
-        99,
-        231,
-        250
-      ],
-      "score": {
-        "structural_complexity": 24.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 97.36363,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/test_macos_collectors.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.90000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 18"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/error.rs": {
-      "content_hash": [
-        18,
-        7,
-        175,
-        226,
-        71,
-        134,
-        175,
-        118,
-        202,
-        163,
-        165,
-        176,
-        127,
-        50,
-        78,
-        198,
-        45,
-        132,
-        149,
-        223,
-        124,
-        116,
-        197,
-        193,
-        156,
-        178,
-        20,
-        158,
-        21,
-        255,
-        193,
-        49
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 6.0,
-        "total": 96.36363,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/error.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 4.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 8 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/force_graph.rs": {
-      "content_hash": [
-        156,
-        94,
-        90,
-        151,
-        96,
-        234,
-        64,
-        17,
-        253,
-        166,
-        240,
-        133,
-        229,
-        216,
-        107,
-        104,
-        164,
-        105,
-        67,
-        195,
-        204,
-        7,
-        197,
-        105,
-        203,
-        193,
-        103,
-        144,
-        55,
-        171,
-        54,
-        248
-      ],
-      "score": {
-        "structural_complexity": 24.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/force_graph.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 17"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/mod.rs": {
-      "content_hash": [
-        61,
-        178,
-        50,
-        84,
-        225,
-        185,
-        186,
-        84,
-        104,
-        19,
-        174,
-        116,
-        121,
-        140,
-        246,
-        25,
-        158,
-        52,
-        135,
-        25,
-        228,
-        252,
-        121,
-        138,
-        234,
-        183,
-        118,
-        49,
-        23,
-        83,
-        182,
-        178
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/output/svg.rs": {
-      "content_hash": [
-        51,
-        37,
-        137,
-        160,
-        136,
-        238,
-        214,
-        146,
-        46,
-        146,
-        18,
-        64,
-        22,
-        234,
-        231,
-        139,
-        27,
-        21,
-        221,
-        129,
-        231,
-        30,
-        56,
-        62,
-        249,
-        29,
-        83,
-        124,
-        247,
-        228,
-        48,
-        152
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.898954,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.635414,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/output/svg.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1010451,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 62 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/table.rs": {
-      "content_hash": [
-        177,
-        133,
-        168,
-        51,
-        202,
-        41,
-        136,
-        31,
-        255,
-        214,
-        183,
-        93,
-        207,
-        74,
-        182,
-        104,
-        110,
-        28,
-        52,
-        94,
-        39,
-        7,
-        172,
-        208,
-        237,
-        78,
-        141,
-        56,
-        17,
-        182,
-        95,
-        214
-      ],
-      "score": {
-        "structural_complexity": 18.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.763285,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.163284,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/table.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.2367148,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 40 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.6000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 37"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/pkg/trueno_viz_wasm_bg.wasm.d.ts": {
-      "content_hash": [
-        175,
-        138,
-        164,
-        33,
-        5,
-        130,
-        139,
-        253,
-        41,
-        233,
-        32,
-        95,
-        119,
-        88,
-        197,
-        150,
-        253,
-        208,
-        154,
-        46,
-        75,
-        230,
-        216,
-        64,
-        192,
-        255,
-        70,
-        107,
-        128,
-        255,
-        3,
-        113
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm_bg.wasm.d.ts",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/examples/collectors.rs": {
-      "content_hash": [
-        81,
-        251,
-        72,
-        116,
-        181,
-        141,
-        37,
-        48,
-        12,
-        8,
-        22,
-        241,
-        215,
-        16,
-        47,
-        48,
-        199,
-        254,
-        111,
-        205,
-        142,
-        15,
-        72,
-        114,
-        62,
-        156,
-        141,
-        203,
-        195,
-        250,
-        0,
-        108
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/examples/collectors.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/app.rs": {
-      "content_hash": [
-        113,
-        82,
-        171,
-        228,
-        224,
-        210,
-        146,
-        78,
-        127,
-        219,
-        162,
-        173,
-        164,
-        59,
-        253,
-        140,
-        231,
-        131,
-        125,
-        239,
-        131,
-        107,
-        45,
-        62,
-        1,
-        143,
-        178,
-        221,
-        41,
-        7,
-        168,
-        95
-      ],
-      "score": {
-        "structural_complexity": 23.8,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.36364,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/app.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.2,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 19"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/gpu_amd.rs": {
-      "content_hash": [
-        210,
-        229,
-        118,
-        30,
-        59,
-        235,
-        42,
-        169,
-        25,
-        181,
-        156,
-        202,
-        178,
-        24,
-        224,
-        110,
-        57,
-        76,
-        47,
-        97,
-        144,
-        185,
-        209,
-        84,
-        226,
-        89,
-        231,
-        57,
-        100,
-        121,
-        180,
-        165
-      ],
-      "score": {
-        "structural_complexity": 21.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.454544,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/gpu_amd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 22 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.3000002,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 26"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/ffi/iokit.rs": {
-      "content_hash": [
-        254,
-        221,
-        98,
-        167,
-        101,
-        191,
-        74,
-        211,
-        120,
-        106,
-        93,
-        241,
-        154,
-        124,
-        194,
-        111,
-        206,
-        241,
-        224,
-        131,
-        152,
-        133,
-        183,
-        1,
-        55,
-        247,
-        119,
-        149,
-        118,
-        110,
-        234,
-        154
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/ffi/iokit.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/sparkline.rs": {
-      "content_hash": [
-        14,
-        128,
-        37,
-        61,
-        229,
-        206,
-        170,
-        90,
-        156,
-        38,
-        100,
-        20,
-        203,
-        102,
-        155,
-        133,
-        166,
-        80,
-        233,
-        76,
-        88,
-        170,
-        103,
-        56,
-        133,
-        207,
-        124,
-        220,
-        231,
-        237,
-        75,
-        250
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.628975,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.628975,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/sparkline.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.3710246,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 26.9%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 29 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/widgets/experiment/sparkline.rs": {
-      "content_hash": [
-        202,
-        217,
-        228,
-        223,
-        118,
-        132,
-        89,
-        255,
-        248,
-        93,
-        83,
-        67,
-        23,
-        162,
-        190,
-        19,
-        36,
-        107,
-        160,
-        46,
-        129,
-        219,
-        192,
-        64,
-        182,
-        162,
-        149,
-        190,
-        166,
-        225,
-        246,
-        10
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.805908,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.459915,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/widgets/experiment/sparkline.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 11 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.1940928,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.0%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/storage.rs": {
-      "content_hash": [
-        184,
-        198,
-        231,
-        30,
-        116,
-        208,
-        165,
-        55,
-        130,
-        57,
-        147,
-        43,
-        121,
-        158,
-        115,
-        206,
-        46,
-        66,
-        216,
-        143,
-        239,
-        44,
-        112,
-        149,
-        206,
-        79,
-        181,
-        254,
-        20,
-        60,
-        35,
-        205
-      ],
-      "score": {
-        "structural_complexity": 18.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.935102,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 96.335106,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/storage.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 46 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.6000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 37"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0648968,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.3%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/error.rs": {
-      "content_hash": [
-        161,
-        150,
-        207,
-        170,
-        65,
-        102,
-        37,
-        190,
-        21,
-        122,
-        7,
-        27,
-        88,
-        21,
-        110,
-        244,
-        71,
-        243,
-        161,
-        76,
-        108,
-        89,
-        88,
-        90,
-        254,
-        102,
-        68,
-        81,
-        39,
-        104,
-        70,
-        76
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/error.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/meter.rs": {
-      "content_hash": [
-        190,
-        11,
-        232,
-        11,
-        237,
-        127,
-        141,
-        240,
-        185,
-        218,
-        70,
-        71,
-        185,
-        6,
-        249,
-        159,
-        66,
-        160,
-        0,
-        164,
-        148,
-        222,
-        112,
-        43,
-        27,
-        24,
-        254,
-        215,
-        193,
-        158,
-        68,
-        177
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 98.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/meter.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/widgets/experiment/mod.rs": {
-      "content_hash": [
-        201,
-        228,
-        133,
-        200,
-        103,
-        223,
-        161,
-        44,
-        130,
-        32,
-        205,
-        157,
-        253,
-        254,
-        248,
-        10,
-        219,
-        7,
-        86,
-        15,
-        242,
-        72,
-        253,
-        240,
-        54,
-        104,
-        242,
-        143,
-        19,
-        146,
-        15,
-        227
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/widgets/experiment/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/framebuffer_benchmark.rs": {
-      "content_hash": [
-        207,
-        175,
-        211,
-        189,
-        192,
-        139,
-        132,
-        199,
-        0,
-        32,
-        180,
-        59,
-        193,
-        166,
-        37,
-        42,
-        116,
-        207,
-        150,
-        197,
-        18,
-        68,
-        107,
-        52,
-        93,
-        138,
-        159,
-        178,
-        11,
-        231,
-        121,
-        121
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 98.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/framebuffer_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/playwright.config.ts": {
-      "content_hash": [
-        18,
-        134,
-        36,
-        31,
-        84,
-        164,
-        22,
-        249,
-        82,
-        10,
-        201,
-        212,
-        104,
-        27,
-        171,
-        168,
-        229,
-        206,
-        239,
-        108,
-        119,
-        119,
-        140,
-        88,
-        18,
-        158,
-        51,
-        79,
-        54,
-        109,
-        38,
-        14
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./wasm-pkg/playwright.config.ts",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/containers.rs": {
-      "content_hash": [
-        178,
-        133,
-        172,
-        189,
-        10,
-        185,
-        95,
-        47,
-        11,
-        253,
-        184,
-        174,
-        166,
-        9,
-        184,
-        175,
-        245,
-        98,
-        31,
-        89,
-        112,
-        193,
-        232,
-        252,
-        198,
-        94,
-        113,
-        78,
-        42,
-        54,
-        129,
-        55
-      ],
-      "score": {
-        "structural_complexity": 23.8,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.36364,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/containers.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 24 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.2,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 19"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/color.rs": {
-      "content_hash": [
-        34,
-        96,
-        13,
-        235,
-        215,
-        223,
-        153,
-        255,
-        167,
-        232,
-        202,
-        199,
-        77,
-        102,
-        242,
-        0,
-        89,
-        59,
-        196,
-        57,
-        6,
-        26,
-        217,
-        29,
-        46,
-        252,
-        132,
-        65,
-        63,
-        175,
-        56,
-        190
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.0,
-        "total": 97.27273,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/color.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 6 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/ui.rs": {
-      "content_hash": [
-        188,
-        245,
-        24,
-        208,
-        119,
-        125,
-        188,
-        79,
-        235,
-        242,
-        76,
-        123,
-        212,
-        159,
-        66,
-        71,
-        244,
-        70,
-        254,
-        68,
-        210,
-        110,
-        191,
-        54,
-        254,
-        21,
-        49,
-        19,
-        129,
-        28,
-        43,
-        255
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 13.991632,
-        "coupling_score": 12.2,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 71.191635,
-        "grade": "BMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/ui.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 87"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 6.008368,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 30.0%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 81"
-          },
-          {
-            "source_metric": "Coupling",
-            "amount": 2.8,
-            "applied_to": [
-              "Coupling"
-            ],
-            "issue": "Too many imports: 34"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 113 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/heatmap_correlation.rs": {
-      "content_hash": [
-        64,
-        203,
-        186,
-        244,
-        190,
-        136,
-        238,
-        253,
-        137,
-        159,
-        170,
-        125,
-        155,
-        130,
-        39,
-        196,
-        238,
-        181,
-        28,
-        124,
-        176,
-        28,
-        77,
-        16,
-        115,
-        50,
-        25,
-        37,
-        228,
-        44,
-        117,
-        211
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/heatmap_correlation.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/coord.rs": {
-      "content_hash": [
-        146,
-        6,
-        109,
-        223,
-        241,
-        17,
-        89,
-        199,
-        41,
-        25,
-        55,
-        183,
-        101,
-        107,
-        21,
-        6,
-        241,
-        253,
-        135,
-        159,
-        61,
-        141,
-        162,
-        73,
-        26,
-        31,
-        112,
-        73,
-        29,
-        167,
-        59,
-        38
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/coord.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 14 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/pkg/trueno_viz_wasm.js": {
-      "content_hash": [
-        102,
-        65,
-        31,
-        248,
-        158,
-        145,
-        207,
-        197,
-        25,
-        187,
-        53,
-        119,
-        244,
-        81,
-        178,
-        179,
-        161,
-        231,
-        101,
-        16,
-        3,
-        84,
-        33,
-        122,
-        107,
-        118,
-        232,
-        73,
-        141,
-        146,
-        188,
-        158
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.867257,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.867256,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 80 duplicate code patterns"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.132743,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 25.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/dashboard_widgets.rs": {
-      "content_hash": [
-        107,
-        199,
-        247,
-        10,
-        138,
-        176,
-        11,
-        177,
-        69,
-        133,
-        143,
-        187,
-        164,
-        26,
-        103,
-        159,
-        78,
-        212,
-        137,
-        171,
-        172,
-        88,
-        6,
-        62,
-        125,
-        225,
-        207,
-        83,
-        112,
-        16,
-        3,
-        52
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.72727,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/dashboard_widgets.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/gpu_apple.rs": {
-      "content_hash": [
-        61,
-        35,
-        84,
-        238,
-        104,
-        98,
-        61,
-        50,
-        138,
-        22,
-        198,
-        244,
-        71,
-        27,
-        206,
-        87,
-        72,
-        243,
-        37,
-        153,
-        124,
-        114,
-        198,
-        82,
-        41,
-        13,
-        182,
-        35,
-        76,
-        33,
-        46,
-        179
-      ],
-      "score": {
-        "structural_complexity": 6.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 86.5,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/gpu_apple.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 122"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 7 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 41"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 22 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/disk_simd.rs": {
-      "content_hash": [
-        100,
-        249,
-        111,
-        240,
-        163,
-        207,
-        1,
-        152,
-        247,
-        130,
-        240,
-        244,
-        114,
-        131,
-        108,
-        41,
-        18,
-        42,
-        122,
-        232,
-        137,
-        10,
-        221,
-        103,
-        87,
-        137,
-        143,
-        28,
-        241,
-        120,
-        183,
-        75
-      ],
-      "score": {
-        "structural_complexity": 23.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.818184,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/disk_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.8000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 21"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 16 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/heatmap_benchmark.rs": {
-      "content_hash": [
-        155,
-        222,
-        234,
-        26,
-        170,
-        54,
-        212,
-        225,
-        39,
-        75,
-        153,
-        255,
-        75,
-        69,
-        215,
-        155,
-        71,
-        120,
-        185,
-        231,
-        121,
-        81,
-        150,
-        165,
-        229,
-        160,
-        239,
-        75,
-        181,
-        245,
-        153,
-        235
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.969696,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.69972,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/heatmap_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.030303,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 16 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/mod.rs": {
-      "content_hash": [
-        20,
-        145,
-        157,
-        251,
-        161,
-        249,
-        205,
-        79,
-        9,
-        68,
-        201,
-        69,
-        188,
-        145,
-        252,
-        102,
-        45,
-        163,
-        100,
-        110,
-        50,
-        92,
-        147,
-        90,
-        154,
-        191,
-        91,
-        3,
-        125,
-        92,
-        76,
-        163
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/state.rs": {
-      "content_hash": [
-        232,
-        246,
-        37,
-        56,
-        250,
-        155,
-        49,
-        70,
-        188,
-        160,
-        131,
-        55,
-        141,
-        175,
-        207,
-        71,
-        121,
-        9,
-        30,
-        215,
-        95,
-        175,
-        72,
-        236,
-        237,
-        117,
-        243,
-        57,
-        221,
-        47,
-        93,
-        143
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 6.5,
-        "total": 96.81818,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/state.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 7 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/mod.rs": {
-      "content_hash": [
-        213,
-        116,
-        151,
-        0,
-        112,
-        211,
-        123,
-        28,
-        206,
-        20,
-        145,
-        46,
-        99,
-        227,
-        247,
-        110,
-        95,
-        209,
-        38,
-        14,
-        83,
-        106,
-        205,
-        28,
-        191,
-        200,
-        185,
-        143,
-        9,
-        176,
-        203,
-        41
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/debug.rs": {
-      "content_hash": [
-        98,
-        37,
-        230,
-        252,
-        173,
-        212,
-        13,
-        88,
-        122,
-        17,
-        215,
-        15,
-        24,
-        51,
-        102,
-        20,
-        112,
-        115,
-        144,
-        205,
-        173,
-        20,
-        21,
-        222,
-        19,
-        6,
-        128,
-        4,
-        81,
-        11,
-        87,
-        151
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/debug.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 17 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/heatmap.rs": {
-      "content_hash": [
-        49,
-        240,
-        61,
-        16,
-        24,
-        238,
-        183,
-        189,
-        116,
-        149,
-        144,
-        152,
-        185,
-        235,
-        46,
-        230,
-        29,
-        47,
-        78,
-        145,
-        151,
-        179,
-        189,
-        106,
-        151,
-        189,
-        23,
-        8,
-        96,
-        181,
-        228,
-        96
-      ],
-      "score": {
-        "structural_complexity": 24.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.862745,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.78432,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/heatmap.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 22 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.90000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 18"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.137255,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/sensor_health.rs": {
-      "content_hash": [
-        152,
-        122,
-        157,
-        25,
-        1,
-        161,
-        251,
-        137,
-        24,
-        190,
-        66,
-        79,
-        53,
-        210,
-        107,
-        187,
-        12,
-        16,
-        11,
-        203,
-        123,
-        129,
-        112,
-        16,
-        51,
-        145,
-        247,
-        177,
-        242,
-        29,
-        248,
-        217
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.382374,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 75.38237,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/sensor_health.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 125 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 89"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 91"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.6176257,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 23.1%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/renacer_hang_tests.rs": {
-      "content_hash": [
-        150,
-        209,
-        136,
-        128,
-        175,
-        134,
-        3,
-        54,
-        70,
-        205,
-        249,
-        42,
-        235,
-        79,
-        206,
-        40,
-        223,
-        61,
-        239,
-        239,
-        26,
-        227,
-        39,
-        15,
-        188,
-        80,
-        254,
-        247,
-        111,
-        11,
-        132,
-        102
-      ],
-      "score": {
-        "structural_complexity": 24.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.637169,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.851974,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/renacer_hang_tests.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.3628318,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.8%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 49 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 17"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/output/mod.rs": {
-      "content_hash": [
-        192,
-        47,
-        248,
-        82,
-        97,
-        33,
-        194,
-        234,
-        161,
-        156,
-        166,
-        211,
-        43,
-        253,
-        221,
-        0,
-        251,
-        89,
-        112,
-        13,
-        204,
-        163,
-        254,
-        139,
-        237,
-        13,
-        214,
-        18,
-        8,
-        255,
-        225,
-        154
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/output/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/examples/simple.rs": {
-      "content_hash": [
-        60,
-        144,
-        180,
-        215,
-        229,
-        80,
-        142,
-        121,
-        27,
-        57,
-        36,
-        216,
-        125,
-        212,
-        152,
-        251,
-        56,
-        87,
-        49,
-        252,
-        231,
-        187,
-        41,
-        26,
-        205,
-        15,
-        4,
-        233,
-        73,
-        173,
-        215,
-        133
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/examples/simple.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/scatter_basic.rs": {
-      "content_hash": [
-        145,
-        74,
-        164,
-        42,
-        93,
-        8,
-        202,
-        244,
-        240,
-        205,
-        18,
-        22,
-        158,
-        224,
-        215,
-        156,
-        70,
-        88,
-        166,
-        207,
-        188,
-        129,
-        182,
-        6,
-        140,
-        76,
-        180,
-        17,
-        125,
-        152,
-        168,
-        56
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/scatter_basic.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/roc_pr.rs": {
-      "content_hash": [
-        42,
-        56,
-        208,
-        199,
-        226,
-        242,
-        9,
-        88,
-        40,
-        253,
-        124,
-        11,
-        169,
-        184,
-        80,
-        54,
-        88,
-        247,
-        199,
-        180,
-        212,
-        137,
-        20,
-        52,
-        13,
-        165,
-        61,
-        238,
-        216,
-        143,
-        61,
-        83
-      ],
-      "score": {
-        "structural_complexity": 22.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.605954,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 96.60596,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/roc_pr.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 102 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 25"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.394046,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 27.0%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/terminal_output.rs": {
-      "content_hash": [
-        121,
-        155,
-        111,
-        179,
-        13,
-        143,
-        90,
-        249,
-        155,
-        92,
-        33,
-        67,
-        247,
-        146,
-        86,
-        150,
-        1,
-        251,
-        229,
-        251,
-        207,
-        153,
-        208,
-        215,
-        167,
-        205,
-        114,
-        10,
-        46,
-        107,
-        69,
-        66
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/terminal_output.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/main.rs": {
-      "content_hash": [
-        246,
-        239,
-        28,
-        1,
-        108,
-        181,
-        68,
-        145,
-        78,
-        42,
-        157,
-        183,
-        174,
-        125,
-        215,
-        176,
-        32,
-        85,
-        197,
-        72,
-        160,
-        138,
-        64,
-        16,
-        161,
-        16,
-        73,
-        162,
-        122,
-        121,
-        81,
-        52
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/main.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/layout.rs": {
-      "content_hash": [
-        231,
-        166,
-        14,
-        192,
-        138,
-        82,
-        194,
-        27,
-        81,
-        191,
-        66,
-        70,
-        185,
-        222,
-        11,
-        247,
-        45,
-        195,
-        210,
-        31,
-        99,
-        211,
-        24,
-        66,
-        150,
-        251,
-        117,
-        146,
-        251,
-        41,
-        120,
-        135
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.869823,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.51803,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/layout.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 17 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.1301775,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/file_analyzer.rs": {
-      "content_hash": [
-        179,
-        134,
-        5,
-        180,
-        77,
-        156,
-        171,
-        37,
-        95,
-        19,
-        212,
-        2,
-        167,
-        119,
-        5,
-        40,
-        201,
-        220,
-        27,
-        131,
-        124,
-        141,
-        6,
-        160,
-        210,
-        55,
-        182,
-        236,
-        159,
-        41,
-        119,
-        6
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 80.0,
-        "grade": "BPlus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/file_analyzer.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 98"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 122"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 48 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/widgets/mod.rs": {
-      "content_hash": [
-        10,
-        35,
-        158,
-        18,
-        144,
-        226,
-        177,
-        150,
-        164,
-        223,
-        72,
-        28,
-        212,
-        99,
-        231,
-        241,
-        106,
-        153,
-        178,
-        136,
-        208,
-        40,
-        86,
-        231,
-        73,
-        176,
-        57,
-        26,
-        232,
-        160,
-        92,
-        219
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/widgets/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/widgets/experiment/run_table.rs": {
-      "content_hash": [
-        240,
-        217,
-        77,
-        129,
-        113,
-        75,
-        137,
-        208,
-        23,
-        135,
-        180,
-        162,
-        167,
-        54,
-        25,
-        90,
-        9,
-        228,
-        28,
-        168,
-        124,
-        43,
-        45,
-        5,
-        12,
-        30,
-        89,
-        25,
-        124,
-        57,
-        219,
-        219
-      ],
-      "score": {
-        "structural_complexity": 22.3,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.505112,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.805115,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/widgets/experiment/run_table.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.2,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 19"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.4948876,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 34 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 33"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/scatter.rs": {
-      "content_hash": [
-        146,
-        143,
-        71,
-        199,
-        88,
-        162,
-        141,
-        136,
-        241,
-        5,
-        244,
-        226,
-        158,
-        186,
-        210,
-        140,
-        238,
-        51,
-        77,
-        180,
-        205,
-        204,
-        134,
-        99,
-        40,
-        225,
-        65,
-        145,
-        9,
-        202,
-        250,
-        63
-      ],
-      "score": {
-        "structural_complexity": 23.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.756098,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.96009,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/scatter.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 17"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.2439024,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 14 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/panels/memory.rs": {
-      "content_hash": [
-        98,
-        187,
-        16,
-        9,
-        94,
-        225,
-        117,
-        196,
-        117,
-        204,
-        100,
-        23,
-        87,
-        235,
-        108,
-        119,
-        170,
-        123,
-        58,
-        113,
-        255,
-        243,
-        100,
-        72,
-        47,
-        6,
-        166,
-        186,
-        205,
-        190,
-        77,
-        163
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/memory.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/aes.rs": {
-      "content_hash": [
-        216,
-        236,
-        30,
-        234,
-        46,
-        36,
-        15,
-        8,
-        244,
-        135,
-        245,
-        68,
-        219,
-        247,
-        90,
-        131,
-        121,
-        51,
-        37,
-        128,
-        18,
-        172,
-        163,
-        229,
-        155,
-        79,
-        53,
-        203,
-        55,
-        180,
-        154,
-        188
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 98.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/aes.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/theme-dawn.js": {
-      "content_hash": [
-        224,
-        153,
-        56,
-        154,
-        73,
-        73,
-        47,
-        60,
-        173,
-        253,
-        234,
-        226,
-        58,
-        250,
-        84,
-        2,
-        147,
-        47,
-        105,
-        0,
-        79,
-        181,
-        190,
-        177,
-        155,
-        154,
-        230,
-        28,
-        8,
-        4,
-        145,
-        82
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/theme-dawn.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/ring_buffer.rs": {
-      "content_hash": [
-        111,
-        237,
-        150,
-        30,
-        4,
-        170,
-        94,
-        118,
-        81,
-        26,
-        2,
-        218,
-        55,
-        71,
-        28,
-        236,
-        223,
-        55,
-        237,
-        89,
-        242,
-        43,
-        228,
-        116,
-        34,
-        130,
-        195,
-        95,
-        132,
-        1,
-        216,
-        105
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.869566,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.608696,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/ring_buffer.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1304348,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.7%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 43 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/encoder_benchmark.rs": {
-      "content_hash": [
-        161,
-        138,
-        132,
-        199,
-        31,
-        3,
-        6,
-        250,
-        118,
-        56,
-        33,
-        187,
-        175,
-        26,
-        243,
-        99,
-        228,
-        57,
-        53,
-        92,
-        199,
-        96,
-        104,
-        79,
-        168,
-        102,
-        6,
-        152,
-        14,
-        193,
-        30,
-        26
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.818182,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.56198,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/encoder_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.181818,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.9%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 15 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/interop/mod.rs": {
-      "content_hash": [
-        169,
-        92,
-        28,
-        107,
-        102,
-        225,
-        195,
-        169,
-        93,
-        113,
-        222,
-        146,
-        183,
-        200,
-        33,
-        134,
-        7,
-        140,
-        76,
-        249,
-        244,
-        192,
-        168,
-        98,
-        139,
-        119,
-        10,
-        79,
-        174,
-        234,
-        39,
-        216
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.555555,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 95.05051,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/interop/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 4.4444447,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 22.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/toc.js": {
-      "content_hash": [
-        105,
-        104,
-        106,
-        145,
-        75,
-        28,
-        63,
-        114,
-        102,
-        236,
-        233,
-        21,
-        145,
-        130,
-        97,
-        113,
-        26,
-        210,
-        181,
-        194,
-        10,
-        18,
-        19,
-        180,
-        199,
-        141,
-        122,
-        104,
-        157,
-        213,
-        137,
-        254
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/toc.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/grammar_of_graphics.rs": {
-      "content_hash": [
-        182,
-        214,
-        178,
-        28,
-        145,
-        208,
-        83,
-        44,
-        29,
-        55,
-        96,
-        23,
-        114,
-        203,
-        222,
-        55,
-        32,
-        253,
-        109,
-        195,
-        0,
-        47,
-        183,
-        109,
-        53,
-        124,
-        43,
-        57,
-        57,
-        216,
-        155,
-        18
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.462585,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.23871,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/grammar_of_graphics.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 13 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.537415,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/histogram.rs": {
-      "content_hash": [
-        158,
-        140,
-        157,
-        37,
-        186,
-        105,
-        46,
-        87,
-        22,
-        246,
-        94,
-        10,
-        115,
-        23,
-        253,
-        5,
-        51,
-        237,
-        210,
-        126,
-        75,
-        215,
-        67,
-        112,
-        232,
-        237,
-        35,
-        102,
-        220,
-        11,
-        152,
-        216
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.23036,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 77.23036,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/histogram.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 14.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 58"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.7696404,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 13.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 106"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 49 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/stack.rs": {
-      "content_hash": [
-        201,
-        195,
-        248,
-        198,
-        247,
-        68,
-        120,
-        115,
-        80,
-        101,
-        210,
-        2,
-        53,
-        252,
-        12,
-        124,
-        121,
-        234,
-        40,
-        56,
-        237,
-        110,
-        246,
-        216,
-        220,
-        81,
-        253,
-        59,
-        42,
-        133,
-        235,
-        0
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/stack.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/mod.rs": {
-      "content_hash": [
-        149,
-        30,
-        236,
-        238,
-        93,
-        233,
-        34,
-        42,
-        27,
-        248,
-        40,
-        137,
-        163,
-        245,
-        225,
-        63,
-        166,
-        181,
-        123,
-        46,
-        221,
-        101,
-        224,
-        30,
-        6,
-        50,
-        178,
-        227,
-        72,
-        136,
-        15,
-        149
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/accel/mod.rs": {
-      "content_hash": [
-        138,
-        135,
-        39,
-        62,
-        192,
-        204,
-        169,
-        55,
-        47,
-        8,
-        183,
-        56,
-        171,
-        149,
-        156,
-        100,
-        151,
-        134,
-        7,
-        167,
-        40,
-        144,
-        164,
-        83,
-        131,
-        149,
-        74,
-        235,
-        246,
-        95,
-        22,
-        62
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/accel/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/text_prompt.rs": {
-      "content_hash": [
-        120,
-        30,
-        94,
-        202,
-        170,
-        20,
-        74,
-        247,
-        73,
-        131,
-        81,
-        162,
-        86,
-        176,
-        105,
-        214,
-        120,
-        171,
-        189,
-        58,
-        142,
-        53,
-        182,
-        3,
-        31,
-        40,
-        164,
-        196,
-        103,
-        74,
-        228,
-        201
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.585365,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 94.62306,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/text_prompt.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.4146342,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.1%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/network_stats.rs": {
-      "content_hash": [
-        153,
-        254,
-        244,
-        1,
-        24,
-        175,
-        149,
-        22,
-        252,
-        50,
-        174,
-        207,
-        71,
-        236,
-        44,
-        59,
-        127,
-        238,
-        165,
-        73,
-        42,
-        197,
-        250,
-        95,
-        100,
-        105,
-        55,
-        252,
-        225,
-        93,
-        20,
-        127
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.834394,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 77.8344,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/network_stats.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.165605,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 107"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 41 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 68"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./tests/wgpu_multi_gpu_test.rs": {
-      "content_hash": [
-        162,
-        220,
-        255,
-        120,
-        161,
-        239,
-        186,
-        252,
-        150,
-        51,
-        192,
-        42,
-        183,
-        77,
-        97,
-        13,
-        40,
-        148,
-        104,
-        161,
-        163,
-        57,
-        104,
-        242,
-        139,
-        143,
-        156,
-        88,
-        10,
-        106,
-        43,
-        94
-      ],
-      "score": {
-        "structural_complexity": 24.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.028986,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 98.72899,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./tests/wgpu_multi_gpu_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 27 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.3,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 16"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.9710145,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 29.9%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/render/primitives.rs": {
-      "content_hash": [
-        166,
-        84,
-        122,
-        152,
-        37,
-        178,
-        120,
-        40,
-        167,
-        171,
-        98,
-        34,
-        199,
-        161,
-        226,
-        146,
-        39,
-        200,
-        252,
-        53,
-        201,
-        5,
-        63,
-        170,
-        177,
-        157,
-        44,
-        24,
-        228,
-        143,
-        184,
-        255
-      ],
-      "score": {
-        "structural_complexity": 16.8,
-        "semantic_complexity": 19.0,
-        "duplication_ratio": 17.103064,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.90306,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/render/primitives.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 7.2000003,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 39"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 32"
-          },
-          {
-            "source_metric": "SemanticComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "SemanticComplexity"
-            ],
-            "issue": "Too many parameters: 7"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.896936,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 35 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/compressed.rs": {
-      "content_hash": [
-        51,
-        231,
-        246,
-        229,
-        210,
-        127,
-        53,
-        88,
-        207,
-        146,
-        154,
-        67,
-        118,
-        29,
-        233,
-        106,
-        210,
-        110,
-        213,
-        115,
-        205,
-        10,
-        193,
-        93,
-        40,
-        126,
-        177,
-        107,
-        2,
-        231,
-        79,
-        204
-      ],
-      "score": {
-        "structural_complexity": 20.8,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.63637,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/compressed.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 14 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 4.2000003,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 29"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/line_benchmark.rs": {
-      "content_hash": [
-        252,
-        69,
-        205,
-        216,
-        226,
-        129,
-        138,
-        51,
-        191,
-        128,
-        145,
-        235,
-        132,
-        239,
-        1,
-        57,
-        166,
-        231,
-        242,
-        108,
-        51,
-        151,
-        90,
-        164,
-        179,
-        48,
-        66,
-        210,
-        109,
-        72,
-        209,
-        3
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.209303,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.91755,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/line_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.7906978,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.0%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 13 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/panels/process.rs": {
-      "content_hash": [
-        115,
-        26,
-        59,
-        116,
-        217,
-        56,
-        201,
-        115,
-        190,
-        109,
-        32,
-        45,
-        140,
-        32,
-        51,
-        16,
-        113,
-        75,
-        165,
-        6,
-        133,
-        0,
-        167,
-        13,
-        202,
-        133,
-        24,
-        148,
-        185,
-        91,
-        165,
-        128
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/process.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/ring_buffer.rs": {
-      "content_hash": [
-        173,
-        69,
-        157,
-        78,
-        249,
-        182,
-        153,
-        116,
-        124,
-        187,
-        162,
-        20,
-        161,
-        142,
-        96,
-        141,
-        173,
-        219,
-        41,
-        99,
-        34,
-        176,
-        215,
-        127,
-        188,
-        10,
-        18,
-        115,
-        113,
-        234,
-        75,
-        108
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.685083,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.44098,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/ring_buffer.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.314917,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.6%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 33 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/mode-rust.js": {
-      "content_hash": [
-        101,
-        114,
-        9,
-        51,
-        84,
-        129,
-        17,
-        132,
-        218,
-        236,
-        175,
-        248,
-        140,
-        136,
-        207,
-        253,
-        237,
-        48,
-        77,
-        178,
-        220,
-        103,
-        158,
-        172,
-        110,
-        226,
-        216,
-        224,
-        153,
-        101,
-        176,
-        180
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/mode-rust.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/panels/files.rs": {
-      "content_hash": [
-        169,
-        79,
-        205,
-        67,
-        147,
-        11,
-        221,
-        132,
-        106,
-        56,
-        161,
-        191,
-        113,
-        207,
-        10,
-        74,
-        229,
-        191,
-        235,
-        2,
-        240,
-        171,
-        179,
-        194,
-        72,
-        183,
-        33,
-        100,
-        52,
-        26,
-        237,
-        207
-      ],
-      "score": {
-        "structural_complexity": 24.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.90909,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/panels/files.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 11 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 17"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/dataframe.rs": {
-      "content_hash": [
-        83,
-        192,
-        55,
-        206,
-        141,
-        197,
-        218,
-        135,
-        160,
-        131,
-        251,
-        19,
-        242,
-        155,
-        227,
-        186,
-        244,
-        80,
-        209,
-        153,
-        49,
-        189,
-        187,
-        187,
-        221,
-        54,
-        167,
-        63,
-        245,
-        139,
-        146,
-        138
-      ],
-      "score": {
-        "structural_complexity": 0.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.732998,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 78.233,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/dataframe.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 105"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 48 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 12.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 55"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.2670026,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.3%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./tests/popperian_falsification_test.rs": {
-      "content_hash": [
-        103,
-        45,
-        38,
-        90,
-        221,
-        69,
-        152,
-        196,
-        244,
-        126,
-        40,
-        192,
-        30,
-        207,
-        77,
-        38,
-        211,
-        17,
-        232,
-        231,
-        198,
-        181,
-        213,
-        246,
-        181,
-        6,
-        194,
-        90,
-        206,
-        153,
-        191,
-        247
-      ],
-      "score": {
-        "structural_complexity": 9.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.816619,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 85.31662,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./tests/popperian_falsification_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 43"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 45"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.183381,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 20.9%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 85 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/theme.rs": {
-      "content_hash": [
-        70,
-        101,
-        222,
-        19,
-        181,
-        196,
-        206,
-        92,
-        141,
-        237,
-        126,
-        115,
-        246,
-        252,
-        126,
-        161,
-        165,
-        196,
-        187,
-        24,
-        204,
-        93,
-        21,
-        156,
-        56,
-        172,
-        104,
-        72,
-        68,
-        114,
-        197,
-        175
-      ],
-      "score": {
-        "structural_complexity": 16.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 96.7,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/theme.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.3,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 36"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/line.rs": {
-      "content_hash": [
-        122,
-        246,
-        245,
-        76,
-        155,
-        123,
-        97,
-        146,
-        249,
-        96,
-        217,
-        16,
-        148,
-        35,
-        171,
-        37,
-        95,
-        165,
-        3,
-        77,
-        1,
-        119,
-        94,
-        154,
-        239,
-        168,
-        104,
-        19,
-        76,
-        215,
-        190,
-        208
-      ],
-      "score": {
-        "structural_complexity": 18.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.874395,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 96.2744,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/line.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.6000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 37"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 25 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.125604,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.6%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/gpu_procs.rs": {
-      "content_hash": [
-        80,
-        25,
-        181,
-        248,
-        109,
-        35,
-        243,
-        239,
-        82,
-        174,
-        248,
-        136,
-        59,
-        117,
-        87,
-        135,
-        32,
-        143,
-        64,
-        154,
-        159,
-        12,
-        85,
-        199,
-        52,
-        106,
-        118,
-        25,
-        106,
-        230,
-        146,
-        94
-      ],
-      "score": {
-        "structural_complexity": 24.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.181816,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/gpu_procs.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.3,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 16"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 14 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/process.rs": {
-      "content_hash": [
-        28,
-        203,
-        173,
-        176,
-        25,
-        242,
-        144,
-        144,
-        67,
-        106,
-        96,
-        75,
-        167,
-        33,
-        20,
-        116,
-        169,
-        81,
-        134,
-        246,
-        218,
-        101,
-        49,
-        46,
-        194,
-        21,
-        225,
-        246,
-        12,
-        135,
-        62,
-        228
-      ],
-      "score": {
-        "structural_complexity": 20.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.090904,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/process.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 36"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.8000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 21"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 39 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/box_violin.rs": {
-      "content_hash": [
-        163,
-        208,
-        156,
-        78,
-        100,
-        107,
-        225,
-        27,
-        21,
-        216,
-        227,
-        194,
-        47,
-        228,
-        109,
-        181,
-        221,
-        233,
-        0,
-        55,
-        53,
-        218,
-        218,
-        246,
-        252,
-        201,
-        189,
-        122,
-        83,
-        104,
-        131,
-        52
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.906977,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.551796,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/box_violin.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 11 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0930233,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.5%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/confusion_matrix_ml.rs": {
-      "content_hash": [
-        97,
-        187,
-        72,
-        241,
-        136,
-        182,
-        78,
-        0,
-        112,
-        163,
-        131,
-        106,
-        187,
-        122,
-        168,
-        24,
-        217,
-        225,
-        9,
-        6,
-        46,
-        78,
-        97,
-        32,
-        90,
-        51,
-        212,
-        125,
-        97,
-        247,
-        167,
-        138
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.52174,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.292496,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/confusion_matrix_ml.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 17 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.478261,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.4%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/scale.rs": {
-      "content_hash": [
-        8,
-        33,
-        149,
-        16,
-        49,
-        191,
-        132,
-        211,
-        33,
-        59,
-        80,
-        96,
-        122,
-        44,
-        210,
-        237,
-        130,
-        137,
-        141,
-        212,
-        81,
-        136,
-        241,
-        201,
-        174,
-        179,
-        148,
-        43,
-        176,
-        154,
-        159,
-        93
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.107843,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.82531,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/scale.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 44 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.8921568,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.5%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/histogram.rs": {
-      "content_hash": [
-        69,
-        149,
-        177,
-        125,
-        84,
-        64,
-        124,
-        5,
-        69,
-        63,
-        8,
-        148,
-        180,
-        239,
-        239,
-        115,
-        179,
-        28,
-        167,
-        239,
-        28,
-        193,
-        116,
-        30,
-        29,
-        160,
-        102,
-        197,
-        82,
-        129,
-        233,
-        182
-      ],
-      "score": {
-        "structural_complexity": 24.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.93811,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.85283,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/histogram.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.90000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 18"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0618892,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.3%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 22 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/verification_specs.rs": {
-      "content_hash": [
-        139,
-        102,
-        214,
-        190,
-        26,
-        234,
-        246,
-        91,
-        230,
-        22,
-        92,
-        208,
-        127,
-        13,
-        140,
-        94,
-        171,
-        89,
-        60,
-        38,
-        251,
-        143,
-        96,
-        154,
-        151,
-        112,
-        219,
-        249,
-        139,
-        27,
-        242,
-        191
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.0,
-        "total": 97.27273,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/verification_specs.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 6 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/wasm.rs": {
-      "content_hash": [
-        87,
-        186,
-        175,
-        49,
-        36,
-        114,
-        184,
-        214,
-        18,
-        118,
-        180,
-        105,
-        63,
-        246,
-        9,
-        195,
-        191,
-        48,
-        198,
-        131,
-        212,
-        39,
-        232,
-        113,
-        221,
-        114,
-        60,
-        86,
-        79,
-        9,
-        45,
-        166
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.844156,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.676506,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/wasm.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 4.155844,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 20.8%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 19 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/panels/mod.rs": {
-      "content_hash": [
-        74,
-        170,
-        252,
-        34,
-        59,
-        39,
-        159,
-        254,
-        90,
-        40,
-        63,
-        197,
-        57,
-        131,
-        127,
-        8,
-        152,
-        184,
-        71,
-        241,
-        88,
-        231,
-        125,
-        126,
-        130,
-        245,
-        200,
-        195,
-        109,
-        235,
-        133,
-        33
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/panels/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/proptest_macos.rs": {
-      "content_hash": [
-        239,
-        73,
-        43,
-        19,
-        192,
-        93,
-        25,
-        82,
-        181,
-        107,
-        134,
-        70,
-        238,
-        19,
-        207,
-        12,
-        237,
-        234,
-        46,
-        127,
-        197,
-        251,
-        69,
-        108,
-        2,
-        80,
-        145,
-        152,
-        23,
-        42,
-        142,
-        156
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.798817,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.635284,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/proptest_macos.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 25 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.2011833,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 21.0%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/network_simd.rs": {
-      "content_hash": [
-        58,
-        41,
-        27,
-        215,
-        14,
-        233,
-        83,
-        14,
-        174,
-        229,
-        4,
-        129,
-        131,
-        19,
-        171,
-        247,
-        188,
-        11,
-        41,
-        90,
-        151,
-        34,
-        100,
-        60,
-        214,
-        119,
-        204,
-        207,
-        135,
-        52,
-        225,
-        117
-      ],
-      "score": {
-        "structural_complexity": 22.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.747253,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.74725,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/network_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 24 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 25"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.2527473,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.3%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/ffi/wgpu.rs": {
-      "content_hash": [
-        157,
-        228,
-        109,
-        230,
-        117,
-        20,
-        139,
-        128,
-        216,
-        74,
-        179,
-        110,
-        178,
-        164,
-        60,
-        71,
-        37,
-        199,
-        135,
-        158,
-        22,
-        126,
-        23,
-        41,
-        51,
-        55,
-        233,
-        222,
-        174,
-        160,
-        49,
-        184
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.084549,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.80413,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/ffi/wgpu.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.9154518,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.6%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 34 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/heatmap.rs": {
-      "content_hash": [
-        246,
-        62,
-        107,
-        189,
-        50,
-        182,
-        195,
-        167,
-        93,
-        0,
-        37,
-        208,
-        223,
-        18,
-        15,
-        119,
-        125,
-        190,
-        251,
-        127,
-        37,
-        233,
-        73,
-        27,
-        221,
-        179,
-        235,
-        135,
-        160,
-        113,
-        204,
-        106
-      ],
-      "score": {
-        "structural_complexity": 23.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.818184,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/heatmap.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 18 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.8000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 21"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/network.rs": {
-      "content_hash": [
-        121,
-        121,
-        40,
-        8,
-        166,
-        161,
-        113,
-        1,
-        221,
-        85,
-        229,
-        85,
-        242,
-        139,
-        108,
-        108,
-        43,
-        12,
-        143,
-        241,
-        27,
-        87,
-        224,
-        17,
-        254,
-        33,
-        33,
-        48,
-        96,
-        254,
-        207,
-        183
-      ],
-      "score": {
-        "structural_complexity": 19.9,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.764471,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 97.664474,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/network.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 37 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.1000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 32"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.235529,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.2%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/disk.rs": {
-      "content_hash": [
-        74,
-        102,
-        83,
-        177,
-        80,
-        88,
-        103,
-        196,
-        180,
-        139,
-        83,
-        65,
-        79,
-        160,
-        114,
-        175,
-        169,
-        222,
-        25,
-        193,
-        155,
-        199,
-        86,
-        26,
-        195,
-        165,
-        156,
-        197,
-        254,
-        140,
-        78,
-        77
-      ],
-      "score": {
-        "structural_complexity": 10.099999,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.54816,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 87.64816,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/disk.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 40"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.451839,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.3%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 54 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.900001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 48"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/violin.rs": {
-      "content_hash": [
-        228,
-        240,
-        236,
-        226,
-        64,
-        101,
-        191,
-        253,
-        66,
-        18,
-        178,
-        236,
-        160,
-        171,
-        144,
-        228,
-        92,
-        200,
-        10,
-        232,
-        202,
-        67,
-        21,
-        63,
-        184,
-        185,
-        87,
-        3,
-        239,
-        167,
-        157,
-        42
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.417912,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 76.41791,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/violin.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5820894,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.9%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 141"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 71"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 100 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/horizon.rs": {
-      "content_hash": [
-        222,
-        203,
-        247,
-        106,
-        230,
-        78,
-        233,
-        19,
-        46,
-        158,
-        21,
-        11,
-        14,
-        247,
-        43,
-        138,
-        216,
-        72,
-        112,
-        7,
-        189,
-        61,
-        99,
-        87,
-        160,
-        177,
-        203,
-        171,
-        32,
-        135,
-        236,
-        55
-      ],
-      "score": {
-        "structural_complexity": 14.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.01818,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.218185,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/horizon.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.9818182,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.9%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 36"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 7.8,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 41"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 37 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/mark.min.js": {
-      "content_hash": [
-        0,
-        169,
-        162,
-        32,
-        56,
-        176,
-        242,
-        242,
-        218,
-        114,
-        99,
-        170,
-        136,
-        103,
-        209,
-        11,
-        165,
-        147,
-        75,
-        232,
-        210,
-        178,
-        180,
-        177,
-        14,
-        218,
-        40,
-        77,
-        0,
-        239,
-        126,
-        137
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/mark.min.js",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/pkg/trueno_viz_wasm.d.ts": {
-      "content_hash": [
-        181,
-        121,
-        73,
-        150,
-        13,
-        21,
-        116,
-        198,
-        153,
-        8,
-        15,
-        103,
-        219,
-        122,
-        252,
-        20,
-        154,
-        61,
-        119,
-        93,
-        153,
-        30,
-        149,
-        34,
-        119,
-        49,
-        253,
-        140,
-        197,
-        103,
-        235,
-        206
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./wasm-pkg/pkg/trueno_viz_wasm.d.ts",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 11 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/searcher.js": {
-      "content_hash": [
-        183,
-        88,
-        191,
-        155,
-        45,
-        157,
-        186,
-        140,
-        59,
-        165,
-        253,
-        192,
-        3,
-        249,
-        95,
-        175,
-        206,
-        28,
-        59,
-        93,
-        218,
-        57,
-        8,
-        29,
-        217,
-        173,
-        167,
-        112,
-        32,
-        251,
-        189,
-        161
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/searcher.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 21 duplicate code patterns"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 5.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent quote usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/presets.rs": {
-      "content_hash": [
-        52,
-        3,
-        64,
-        203,
-        152,
-        221,
-        24,
-        244,
-        205,
-        83,
-        252,
-        123,
-        251,
-        222,
-        25,
-        177,
-        109,
-        49,
-        2,
-        146,
-        61,
-        64,
-        134,
-        193,
-        163,
-        124,
-        191,
-        244,
-        162,
-        92,
-        56,
-        196
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.446701,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.22427,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/presets.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5532997,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.8%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 14 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/geoip.rs": {
-      "content_hash": [
-        12,
-        120,
-        167,
-        76,
-        69,
-        50,
-        204,
-        40,
-        136,
-        175,
-        72,
-        92,
-        236,
-        157,
-        98,
-        210,
-        215,
-        20,
-        230,
-        67,
-        255,
-        28,
-        12,
-        146,
-        60,
-        28,
-        247,
-        183,
-        148,
-        252,
-        153,
-        62
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.0,
-        "total": 97.27273,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/geoip.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 6 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/connections.rs": {
-      "content_hash": [
-        212,
-        208,
-        33,
-        112,
-        115,
-        2,
-        139,
-        28,
-        231,
-        117,
-        189,
-        69,
-        173,
-        248,
-        206,
-        190,
-        128,
-        95,
-        12,
-        219,
-        243,
-        12,
-        210,
-        10,
-        243,
-        127,
-        108,
-        110,
-        112,
-        172,
-        159,
-        34
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.38397,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 76.38397,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/connections.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 96"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 136"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.61603,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 18.1%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 67 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/theme.rs": {
-      "content_hash": [
-        169,
-        188,
-        79,
-        241,
-        160,
-        49,
-        215,
-        42,
-        5,
-        52,
-        14,
-        189,
-        16,
-        81,
-        206,
-        7,
-        87,
-        247,
-        116,
-        27,
-        87,
-        72,
-        219,
-        146,
-        9,
-        155,
-        203,
-        58,
-        13,
-        12,
-        136,
-        6
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.785124,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.62284,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/theme.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 23 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.214876,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 21.1%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/panel_evidence_test.rs": {
-      "content_hash": [
-        241,
-        71,
-        219,
-        92,
-        51,
-        44,
-        252,
-        195,
-        242,
-        79,
-        79,
-        230,
-        155,
-        68,
-        187,
-        85,
-        199,
-        120,
-        129,
-        180,
-        80,
-        224,
-        201,
-        210,
-        208,
-        25,
-        187,
-        176,
-        110,
-        166,
-        157,
-        71
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.72727,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/panel_evidence_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/highlight.js": {
-      "content_hash": [
-        94,
-        247,
-        88,
-        103,
-        10,
-        83,
-        7,
-        55,
-        108,
-        239,
-        9,
-        38,
-        56,
-        59,
-        174,
-        9,
-        247,
-        29,
-        91,
-        61,
-        120,
-        251,
-        116,
-        41,
-        88,
-        210,
-        224,
-        97,
-        254,
-        38,
-        205,
-        129
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/highlight.js",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/cpu.rs": {
-      "content_hash": [
-        10,
-        42,
-        187,
-        85,
-        27,
-        31,
-        99,
-        0,
-        168,
-        73,
-        92,
-        215,
-        116,
-        40,
-        129,
-        90,
-        223,
-        20,
-        247,
-        241,
-        236,
-        50,
-        54,
-        19,
-        222,
-        38,
-        81,
-        98,
-        130,
-        219,
-        25,
-        31
-      ],
-      "score": {
-        "structural_complexity": 12.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.09602,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 89.09602,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/cpu.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.9039812,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.5%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 62"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 7 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 77 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./pkg/trueno_viz.d.ts": {
-      "content_hash": [
-        42,
-        130,
-        185,
-        136,
-        93,
-        178,
-        119,
-        219,
-        156,
-        51,
-        115,
-        102,
-        218,
-        245,
-        3,
-        162,
-        143,
-        109,
-        99,
-        107,
-        237,
-        91,
-        212,
-        26,
-        248,
-        34,
-        203,
-        107,
-        167,
-        209,
-        141,
-        123
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.59036,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.26397,
-        "grade": "A",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./pkg/trueno_viz.d.ts",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.4096386,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.0%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/disk_io.rs": {
-      "content_hash": [
-        70,
-        89,
-        218,
-        225,
-        215,
-        54,
-        76,
-        169,
-        167,
-        140,
-        197,
-        131,
-        70,
-        248,
-        31,
-        168,
-        112,
-        94,
-        57,
-        187,
-        214,
-        242,
-        97,
-        41,
-        135,
-        167,
-        27,
-        191,
-        91,
-        156,
-        53,
-        169
-      ],
-      "score": {
-        "structural_complexity": 24.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.90909,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/disk_io.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 29 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 17"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/display_rules.rs": {
-      "content_hash": [
-        33,
-        104,
-        0,
-        226,
-        39,
-        21,
-        25,
-        68,
-        66,
-        19,
-        145,
-        25,
-        121,
-        101,
-        78,
-        116,
-        141,
-        29,
-        144,
-        254,
-        139,
-        161,
-        133,
-        104,
-        24,
-        73,
-        91,
-        0,
-        244,
-        32,
-        111,
-        22
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/display_rules.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 12 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/gpu_nvidia.rs": {
-      "content_hash": [
-        81,
-        56,
-        61,
-        223,
-        40,
-        210,
-        69,
-        0,
-        178,
-        121,
-        146,
-        56,
-        145,
-        177,
-        175,
-        247,
-        247,
-        77,
-        6,
-        93,
-        133,
-        181,
-        16,
-        15,
-        133,
-        20,
-        156,
-        238,
-        147,
-        114,
-        175,
-        77
-      ],
-      "score": {
-        "structural_complexity": 22.9,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.545456,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/gpu_nvidia.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.1000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 22"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 12 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/ggplot.rs": {
-      "content_hash": [
-        34,
-        79,
-        149,
-        242,
-        64,
-        235,
-        248,
-        140,
-        13,
-        90,
-        71,
-        132,
-        173,
-        40,
-        197,
-        111,
-        57,
-        162,
-        4,
-        3,
-        203,
-        38,
-        119,
-        223,
-        130,
-        185,
-        137,
-        5,
-        20,
-        199,
-        114,
-        16
-      ],
-      "score": {
-        "structural_complexity": 8.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.040872,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 83.54087,
-        "grade": "BPlus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/ggplot.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.9591284,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 24.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 55"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 41"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 64 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/book.js": {
-      "content_hash": [
-        30,
-        107,
-        83,
-        113,
-        9,
-        30,
-        79,
-        191,
-        86,
-        42,
-        114,
-        198,
-        167,
-        106,
-        172,
-        80,
-        202,
-        195,
-        89,
-        153,
-        99,
-        120,
-        92,
-        89,
-        4,
-        46,
-        143,
-        66,
-        151,
-        246,
-        28,
-        108
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/book.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 5.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent quote usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 51 duplicate code patterns"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/confusion_matrix.rs": {
-      "content_hash": [
-        76,
-        68,
-        91,
-        54,
-        22,
-        61,
-        165,
-        84,
-        183,
-        246,
-        95,
-        141,
-        65,
-        154,
-        169,
-        171,
-        30,
-        246,
-        186,
-        167,
-        218,
-        239,
-        233,
-        112,
-        2,
-        102,
-        46,
-        182,
-        133,
-        181,
-        11,
-        232
-      ],
-      "score": {
-        "structural_complexity": 13.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.485508,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 89.485504,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/confusion_matrix.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 50"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 34"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 36 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5144928,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.6%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/timeseries.rs": {
-      "content_hash": [
-        57,
-        117,
-        255,
-        26,
-        122,
-        85,
-        214,
-        87,
-        120,
-        244,
-        78,
-        12,
-        66,
-        9,
-        231,
-        91,
-        164,
-        102,
-        86,
-        228,
-        168,
-        128,
-        66,
-        103,
-        116,
-        154,
-        58,
-        130,
-        101,
-        3,
-        237,
-        55
-      ],
-      "score": {
-        "structural_complexity": 6.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 86.0,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/timeseries.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 80"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 35 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 48"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/battery_sensors_simd.rs": {
-      "content_hash": [
-        73,
-        221,
-        154,
-        226,
-        243,
-        144,
-        55,
-        22,
-        168,
-        217,
-        203,
-        243,
-        56,
-        153,
-        197,
-        69,
-        98,
-        244,
-        128,
-        48,
-        26,
-        71,
-        212,
-        145,
-        168,
-        72,
-        58,
-        104,
-        188,
-        224,
-        55,
-        96
-      ],
-      "score": {
-        "structural_complexity": 23.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.956657,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.23332,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/battery_sensors_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 20"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0433435,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 18 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/bin/trueno_agent.rs": {
-      "content_hash": [
-        131,
-        179,
-        114,
-        144,
-        254,
-        3,
-        0,
-        45,
-        94,
-        65,
-        77,
-        239,
-        205,
-        44,
-        186,
-        133,
-        114,
-        58,
-        11,
-        83,
-        159,
-        191,
-        159,
-        80,
-        42,
-        148,
-        211,
-        213,
-        95,
-        18,
-        140,
-        248
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/bin/trueno_agent.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/config.rs": {
-      "content_hash": [
-        25,
-        31,
-        46,
-        90,
-        134,
-        8,
-        78,
-        228,
-        114,
-        66,
-        41,
-        29,
-        209,
-        194,
-        138,
-        194,
-        205,
-        86,
-        145,
-        41,
-        26,
-        156,
-        193,
-        187,
-        95,
-        106,
-        209,
-        151,
-        91,
-        46,
-        41,
-        38
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/config.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 12 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/clipboard.min.js": {
-      "content_hash": [
-        228,
-        7,
-        26,
-        156,
-        206,
-        210,
-        124,
-        20,
-        145,
-        231,
-        75,
-        54,
-        179,
-        199,
-        238,
-        114,
-        182,
-        2,
-        69,
-        99,
-        55,
-        208,
-        1,
-        97,
-        222,
-        234,
-        77,
-        56,
-        211,
-        11,
-        209,
-        88
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/clipboard.min.js",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/integration_tests.rs": {
-      "content_hash": [
-        51,
-        60,
-        12,
-        82,
-        153,
-        139,
-        54,
-        59,
-        34,
-        239,
-        223,
-        92,
-        60,
-        89,
-        57,
-        95,
-        113,
-        253,
-        70,
-        64,
-        22,
-        68,
-        87,
-        122,
-        172,
-        126,
-        224,
-        93,
-        110,
-        201,
-        184,
-        57
-      ],
-      "score": {
-        "structural_complexity": 14.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.343452,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.04346,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/integration_tests.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.6565466,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 13.3%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 7.8,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 41"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 35"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 46 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/soa.rs": {
-      "content_hash": [
-        190,
-        11,
-        75,
-        133,
-        4,
-        164,
-        15,
-        32,
-        122,
-        202,
-        187,
-        69,
-        127,
-        39,
-        202,
-        160,
-        64,
-        2,
-        22,
-        115,
-        209,
-        53,
-        107,
-        36,
-        244,
-        243,
-        13,
-        113,
-        123,
-        83,
-        206,
-        215
-      ],
-      "score": {
-        "structural_complexity": 21.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.95539,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.35539,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/soa.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0446095,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.2%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.6000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 27"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 32 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/sensors.rs": {
-      "content_hash": [
-        224,
-        76,
-        215,
-        3,
-        178,
-        204,
-        197,
-        132,
-        243,
-        40,
-        245,
-        100,
-        103,
-        180,
-        129,
-        53,
-        228,
-        14,
-        191,
-        196,
-        27,
-        224,
-        24,
-        217,
-        57,
-        219,
-        142,
-        141,
-        164,
-        239,
-        33,
-        161
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.150839,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.8644,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/sensors.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.8491619,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 30 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/framebuffer.rs": {
-      "content_hash": [
-        232,
-        146,
-        227,
-        186,
-        33,
-        90,
-        123,
-        173,
-        184,
-        180,
-        3,
-        10,
-        59,
-        100,
-        118,
-        23,
-        255,
-        196,
-        196,
-        230,
-        41,
-        215,
-        135,
-        35,
-        55,
-        209,
-        240,
-        237,
-        85,
-        180,
-        52,
-        102
-      ],
-      "score": {
-        "structural_complexity": 14.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.404922,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.10492,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/framebuffer.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5950785,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 13.0%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 31 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 32"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.3,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 46"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/cpu_simd.rs": {
-      "content_hash": [
-        61,
-        210,
-        5,
-        201,
-        180,
-        2,
-        109,
-        17,
-        236,
-        116,
-        86,
-        204,
-        146,
-        169,
-        156,
-        144,
-        185,
-        14,
-        137,
-        19,
-        33,
-        97,
-        153,
-        251,
-        242,
-        229,
-        228,
-        135,
-        255,
-        18,
-        229,
-        97
-      ],
-      "score": {
-        "structural_complexity": 20.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.27273,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/cpu_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 23 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.6000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 27"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/mod.rs": {
-      "content_hash": [
-        172,
-        100,
-        98,
-        105,
-        232,
-        53,
-        110,
-        50,
-        94,
-        10,
-        26,
-        191,
-        36,
-        90,
-        101,
-        220,
-        198,
-        25,
-        228,
-        228,
-        162,
-        211,
-        81,
-        231,
-        129,
-        32,
-        249,
-        59,
-        28,
-        126,
-        78,
-        22
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/monitor_unit_tests.rs": {
-      "content_hash": [
-        210,
-        24,
-        53,
-        155,
-        109,
-        103,
-        195,
-        7,
-        250,
-        151,
-        123,
-        57,
-        110,
-        24,
-        30,
-        65,
-        188,
-        82,
-        238,
-        252,
-        66,
-        213,
-        214,
-        51,
-        13,
-        127,
-        208,
-        123,
-        177,
-        227,
-        153,
-        186
-      ],
-      "score": {
-        "structural_complexity": 22.6,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.075354,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 98.675354,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/monitor_unit_tests.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.4,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 23"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 49 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.9246466,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 19.6%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/probar_full_test.rs": {
-      "content_hash": [
-        218,
-        46,
-        86,
-        54,
-        116,
-        200,
-        187,
-        17,
-        66,
-        188,
-        28,
-        100,
-        219,
-        49,
-        9,
-        130,
-        131,
-        41,
-        99,
-        91,
-        140,
-        191,
-        77,
-        37,
-        56,
-        168,
-        196,
-        125,
-        72,
-        80,
-        0,
-        4
-      ],
-      "score": {
-        "structural_complexity": 21.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.950531,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.05053,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/probar_full_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.9,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 28"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.04947,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 24 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/confusion.rs": {
-      "content_hash": [
-        70,
-        200,
-        202,
-        214,
-        23,
-        23,
-        208,
-        134,
-        219,
-        187,
-        224,
-        30,
-        40,
-        138,
-        30,
-        50,
-        21,
-        34,
-        155,
-        73,
-        6,
-        61,
-        179,
-        171,
-        255,
-        97,
-        215,
-        65,
-        44,
-        110,
-        150,
-        15
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.871239,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 76.87124,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/confusion.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1287603,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.6%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 49 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 67"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 111"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/input.rs": {
-      "content_hash": [
-        164,
-        105,
-        182,
-        181,
-        90,
-        187,
-        87,
-        245,
-        221,
-        148,
-        170,
-        132,
-        212,
-        72,
-        94,
-        103,
-        2,
-        244,
-        164,
-        181,
-        156,
-        252,
-        128,
-        135,
-        241,
-        81,
-        124,
-        222,
-        210,
-        46,
-        84,
-        143
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.72727,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/input.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/boxplot.rs": {
-      "content_hash": [
-        212,
-        32,
-        217,
-        51,
-        245,
-        72,
-        190,
-        13,
-        158,
-        104,
-        55,
-        50,
-        81,
-        211,
-        99,
-        90,
-        224,
-        42,
-        171,
-        56,
-        246,
-        162,
-        123,
-        168,
-        224,
-        109,
-        121,
-        41,
-        98,
-        111,
-        222,
-        155
-      ],
-      "score": {
-        "structural_complexity": 2.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.32353,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 78.82353,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/boxplot.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.6764705,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 18.4%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 12.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 55"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 110"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 87 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/force_graph.rs": {
-      "content_hash": [
-        37,
-        63,
-        222,
-        83,
-        121,
-        146,
-        204,
-        164,
-        98,
-        54,
-        113,
-        178,
-        33,
-        40,
-        144,
-        232,
-        162,
-        94,
-        54,
-        112,
-        97,
-        205,
-        196,
-        49,
-        42,
-        233,
-        159,
-        209,
-        225,
-        44,
-        76,
-        215
-      ],
-      "score": {
-        "structural_complexity": 22.6,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.997578,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.59758,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/force_graph.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.4,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 23"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 31 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0024214,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.0%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/kernels.rs": {
-      "content_hash": [
-        224,
-        104,
-        31,
-        200,
-        204,
-        240,
-        33,
-        99,
-        78,
-        13,
-        123,
-        106,
-        205,
-        1,
-        225,
-        239,
-        99,
-        28,
-        159,
-        183,
-        3,
-        12,
-        13,
-        9,
-        187,
-        182,
-        32,
-        131,
-        41,
-        229,
-        254,
-        206
-      ],
-      "score": {
-        "structural_complexity": 18.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.82927,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.92927,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/kernels.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1707315,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.9%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.9,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 38"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 23 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/interop/trueno_graph.rs": {
-      "content_hash": [
-        111,
-        198,
-        14,
-        209,
-        119,
-        116,
-        204,
-        86,
-        0,
-        33,
-        226,
-        134,
-        70,
-        86,
-        250,
-        252,
-        74,
-        99,
-        191,
-        111,
-        117,
-        253,
-        21,
-        26,
-        61,
-        248,
-        147,
-        235,
-        25,
-        97,
-        186,
-        254
-      ],
-      "score": {
-        "structural_complexity": 22.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.954955,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 96.954956,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/interop/trueno_graph.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.045045,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 25.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 42 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 25"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/geom.rs": {
-      "content_hash": [
-        146,
-        67,
-        129,
-        162,
-        146,
-        135,
-        204,
-        154,
-        56,
-        128,
-        242,
-        175,
-        65,
-        158,
-        146,
-        157,
-        213,
-        153,
-        130,
-        247,
-        42,
-        244,
-        111,
-        154,
-        241,
-        138,
-        198,
-        58,
-        10,
-        86,
-        164,
-        114
-      ],
-      "score": {
-        "structural_complexity": 17.8,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.487684,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.28768,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/geom.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5123153,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.6%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.7,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 24"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 28 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 4.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 39"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/render/mod.rs": {
-      "content_hash": [
-        172,
-        192,
-        75,
-        78,
-        75,
-        92,
-        39,
-        80,
-        91,
-        136,
-        117,
-        244,
-        82,
-        83,
-        197,
-        222,
-        128,
-        136,
-        104,
-        204,
-        77,
-        157,
-        37,
-        27,
-        201,
-        100,
-        6,
-        164,
-        163,
-        241,
-        233,
-        72
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/render/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/e2e/demo.spec.ts": {
-      "content_hash": [
-        56,
-        15,
-        3,
-        12,
-        183,
-        5,
-        7,
-        8,
-        247,
-        222,
-        124,
-        84,
-        93,
-        22,
-        227,
-        101,
-        16,
-        236,
-        11,
-        236,
-        226,
-        4,
-        223,
-        192,
-        51,
-        51,
-        222,
-        173,
-        41,
-        176,
-        112,
-        148
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.200001,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.090904,
-        "grade": "A",
-        "confidence": 0.9,
-        "language": "TypeScript",
-        "file_path": "./wasm-pkg/e2e/demo.spec.ts",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 24 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.7999997,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 24.0%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/output/png_encoder.rs": {
-      "content_hash": [
-        241,
-        103,
-        61,
-        128,
-        25,
-        147,
-        217,
-        212,
-        30,
-        0,
-        215,
-        158,
-        36,
-        212,
-        160,
-        129,
-        183,
-        174,
-        57,
-        95,
-        19,
-        39,
-        43,
-        0,
-        49,
-        173,
-        35,
-        25,
-        145,
-        255,
-        212,
-        180
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 6.0,
-        "total": 96.36363,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/output/png_encoder.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 4.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 8 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/graph.rs": {
-      "content_hash": [
-        254,
-        115,
-        146,
-        229,
-        191,
-        168,
-        88,
-        182,
-        173,
-        200,
-        229,
-        54,
-        160,
-        184,
-        31,
-        59,
-        140,
-        54,
-        135,
-        71,
-        141,
-        202,
-        29,
-        146,
-        133,
-        60,
-        124,
-        163,
-        118,
-        124,
-        238,
-        69
-      ],
-      "score": {
-        "structural_complexity": 12.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.714286,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 87.71429,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/graph.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 34"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 65"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 38 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.285714,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 21.4%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/ace.js": {
-      "content_hash": [
-        163,
-        128,
-        119,
-        150,
-        206,
-        255,
-        145,
-        112,
-        141,
-        191,
-        173,
-        60,
-        84,
-        163,
-        5,
-        236,
-        26,
-        170,
-        229,
-        138,
-        28,
-        235,
-        161,
-        143,
-        25,
-        166,
-        232,
-        227,
-        171,
-        143,
-        250,
-        32
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/ace.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/output/html.rs": {
-      "content_hash": [
-        198,
-        20,
-        13,
-        188,
-        174,
-        248,
-        68,
-        186,
-        246,
-        213,
-        55,
-        72,
-        17,
-        25,
-        171,
-        153,
-        239,
-        190,
-        39,
-        190,
-        202,
-        185,
-        57,
-        23,
-        4,
-        251,
-        160,
-        206,
-        106,
-        246,
-        208,
-        12
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/output/html.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 19 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/memory_simd.rs": {
-      "content_hash": [
-        135,
-        241,
-        52,
-        73,
-        36,
-        233,
-        163,
-        89,
-        212,
-        251,
-        29,
-        193,
-        177,
-        210,
-        100,
-        225,
-        230,
-        94,
-        213,
-        89,
-        103,
-        13,
-        168,
-        39,
-        118,
-        124,
-        136,
-        1,
-        144,
-        131,
-        25,
-        1
-      ],
-      "score": {
-        "structural_complexity": 10.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 90.0,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/memory_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 11 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 68"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 13 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/lib.rs": {
-      "content_hash": [
-        225,
-        164,
-        167,
-        124,
-        61,
-        184,
-        55,
-        237,
-        63,
-        236,
-        37,
-        244,
-        16,
-        75,
-        161,
-        24,
-        43,
-        102,
-        23,
-        69,
-        226,
-        153,
-        39,
-        86,
-        240,
-        191,
-        201,
-        197,
-        205,
-        253,
-        253,
-        125
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/lib.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/prompt/mod.rs": {
-      "content_hash": [
-        93,
-        221,
-        26,
-        236,
-        154,
-        16,
-        86,
-        139,
-        86,
-        246,
-        161,
-        172,
-        48,
-        232,
-        207,
-        132,
-        42,
-        50,
-        20,
-        35,
-        99,
-        195,
-        179,
-        131,
-        123,
-        101,
-        42,
-        234,
-        142,
-        188,
-        89,
-        162
-      ],
-      "score": {
-        "structural_complexity": 1.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.75,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 78.75,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/prompt/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 13.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 56"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 45"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 27 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.25,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.2%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/lib.rs": {
-      "content_hash": [
-        32,
-        119,
-        95,
-        64,
-        219,
-        154,
-        162,
-        240,
-        55,
-        2,
-        43,
-        210,
-        146,
-        217,
-        26,
-        161,
-        118,
-        199,
-        7,
-        147,
-        128,
-        179,
-        176,
-        153,
-        194,
-        57,
-        84,
-        136,
-        49,
-        50,
-        13,
-        72
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/lib.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/correlation.rs": {
-      "content_hash": [
-        163,
-        106,
-        81,
-        54,
-        70,
-        63,
-        213,
-        1,
-        130,
-        60,
-        182,
-        122,
-        25,
-        200,
-        182,
-        145,
-        137,
-        117,
-        16,
-        27,
-        229,
-        83,
-        135,
-        69,
-        20,
-        48,
-        28,
-        59,
-        175,
-        142,
-        232,
-        238
-      ],
-      "score": {
-        "structural_complexity": 14.9,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 94.9,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/correlation.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 0.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 31"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 21 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.6,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 47"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/data.rs": {
-      "content_hash": [
-        178,
-        206,
-        217,
-        49,
-        66,
-        223,
-        147,
-        29,
-        21,
-        204,
-        64,
-        143,
-        220,
-        126,
-        14,
-        10,
-        250,
-        239,
-        195,
-        51,
-        247,
-        22,
-        102,
-        185,
-        92,
-        11,
-        75,
-        49,
-        250,
-        48,
-        22,
-        132
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.934273,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.57661,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/data.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 17 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0657277,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.3%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/mod.rs": {
-      "content_hash": [
-        33,
-        227,
-        205,
-        78,
-        134,
-        119,
-        62,
-        32,
-        1,
-        20,
-        89,
-        191,
-        44,
-        208,
-        234,
-        75,
-        187,
-        122,
-        99,
-        237,
-        243,
-        88,
-        177,
-        124,
-        10,
-        230,
-        203,
-        125,
-        111,
-        204,
-        197,
-        241
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/mod.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/output/terminal.rs": {
-      "content_hash": [
-        86,
-        219,
-        18,
-        182,
-        36,
-        30,
-        162,
-        152,
-        217,
-        116,
-        93,
-        219,
-        249,
-        6,
-        163,
-        2,
-        64,
-        254,
-        9,
-        224,
-        167,
-        61,
-        241,
-        107,
-        34,
-        162,
-        103,
-        49,
-        235,
-        62,
-        205,
-        243
-      ],
-      "score": {
-        "structural_complexity": 21.7,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.164179,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 98.86418,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/output/terminal.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.3000002,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 26"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.835821,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.2%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 26 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/trueno_graph_integration.rs": {
-      "content_hash": [
-        177,
-        25,
-        150,
-        200,
-        110,
-        174,
-        38,
-        243,
-        244,
-        90,
-        135,
-        232,
-        81,
-        34,
-        254,
-        34,
-        64,
-        89,
-        78,
-        132,
-        28,
-        176,
-        91,
-        189,
-        17,
-        198,
-        0,
-        170,
-        163,
-        226,
-        7,
-        20
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/trueno_graph_integration.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/roc_pr_curves.rs": {
-      "content_hash": [
-        106,
-        13,
-        73,
-        177,
-        123,
-        64,
-        156,
-        177,
-        213,
-        211,
-        237,
-        167,
-        150,
-        205,
-        25,
-        43,
-        87,
-        36,
-        234,
-        228,
-        10,
-        133,
-        186,
-        176,
-        188,
-        225,
-        11,
-        72,
-        77,
-        122,
-        79,
-        60
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 97.72727,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/roc_pr_curves.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 5 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/tree.rs": {
-      "content_hash": [
-        144,
-        104,
-        16,
-        145,
-        118,
-        236,
-        2,
-        248,
-        150,
-        108,
-        35,
-        59,
-        30,
-        37,
-        215,
-        71,
-        171,
-        244,
-        123,
-        191,
-        247,
-        134,
-        47,
-        148,
-        220,
-        242,
-        73,
-        4,
-        30,
-        193,
-        99,
-        52
-      ],
-      "score": {
-        "structural_complexity": 23.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.094675,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.29468,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/tree.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.9053254,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 19.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 26 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.8000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 21"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/swap.rs": {
-      "content_hash": [
-        70,
-        8,
-        239,
-        160,
-        103,
-        76,
-        27,
-        104,
-        16,
-        34,
-        68,
-        35,
-        199,
-        24,
-        127,
-        197,
-        18,
-        131,
-        17,
-        83,
-        86,
-        128,
-        105,
-        57,
-        142,
-        10,
-        94,
-        131,
-        8,
-        124,
-        211,
-        141
-      ],
-      "score": {
-        "structural_complexity": 3.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 83.5,
-        "grade": "BPlus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/swap.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 19 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 60"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 11.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 53"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/ring_buffer.rs": {
-      "content_hash": [
-        43,
-        167,
-        166,
-        133,
-        8,
-        60,
-        179,
-        75,
-        151,
-        248,
-        221,
-        77,
-        78,
-        201,
-        176,
-        155,
-        35,
-        237,
-        161,
-        155,
-        217,
-        97,
-        213,
-        192,
-        204,
-        19,
-        53,
-        24,
-        142,
-        55,
-        235,
-        223
-      ],
-      "score": {
-        "structural_complexity": 22.3,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.902655,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 99.20265,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/ring_buffer.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.7,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 24"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.0973454,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 30 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/ffi/afterburner.rs": {
-      "content_hash": [
-        30,
-        230,
-        1,
-        205,
-        113,
-        34,
-        34,
-        198,
-        135,
-        211,
-        145,
-        17,
-        112,
-        176,
-        62,
-        248,
-        49,
-        35,
-        62,
-        220,
-        26,
-        31,
-        57,
-        60,
-        162,
-        135,
-        220,
-        222,
-        219,
-        195,
-        72,
-        160
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/ffi/afterburner.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/widgets/experiment/resource_bar.rs": {
-      "content_hash": [
-        173,
-        209,
-        89,
-        152,
-        247,
-        236,
-        10,
-        9,
-        215,
-        14,
-        136,
-        193,
-        222,
-        178,
-        50,
-        127,
-        108,
-        120,
-        62,
-        66,
-        32,
-        121,
-        44,
-        129,
-        117,
-        8,
-        69,
-        34,
-        10,
-        60,
-        232,
-        91
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/widgets/experiment/resource_bar.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./pkg/trueno_viz.js": {
-      "content_hash": [
-        185,
-        14,
-        172,
-        161,
-        20,
-        78,
-        227,
-        232,
-        243,
-        189,
-        111,
-        175,
-        242,
-        70,
-        139,
-        48,
-        219,
-        25,
-        224,
-        168,
-        97,
-        24,
-        174,
-        118,
-        179,
-        113,
-        183,
-        21,
-        114,
-        216,
-        167,
-        232
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 15.160745,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.05522,
-        "grade": "A",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./pkg/trueno_viz.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 54 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 4.8392553,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 24.2%"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 5.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent quote usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/battery.rs": {
-      "content_hash": [
-        228,
-        63,
-        4,
-        169,
-        136,
-        61,
-        108,
-        106,
-        121,
-        191,
-        204,
-        171,
-        38,
-        213,
-        133,
-        166,
-        158,
-        244,
-        241,
-        66,
-        91,
-        29,
-        191,
-        111,
-        171,
-        203,
-        225,
-        165,
-        88,
-        120,
-        89,
-        246
-      ],
-      "score": {
-        "structural_complexity": 21.9,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.579573,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 98.479576,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/battery.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.4204273,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.1%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 32"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.1000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 22"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 32 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/editor.js": {
-      "content_hash": [
-        57,
-        158,
-        36,
-        233,
-        200,
-        189,
-        195,
-        102,
-        23,
-        20,
-        192,
-        90,
-        134,
-        111,
-        215,
-        84,
-        116,
-        108,
-        50,
-        173,
-        223,
-        210,
-        255,
-        249,
-        3,
-        112,
-        16,
-        236,
-        239,
-        196,
-        21,
-        6
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 99.545456,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/editor.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 5.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent quote usage detected"
-          },
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./benches/histogram_benchmark.rs": {
-      "content_hash": [
-        95,
-        126,
-        43,
-        0,
-        75,
-        204,
-        197,
-        58,
-        142,
-        42,
-        46,
-        245,
-        98,
-        107,
-        219,
-        126,
-        81,
-        200,
-        248,
-        140,
-        135,
-        206,
-        101,
-        171,
-        76,
-        145,
-        84,
-        196,
-        63,
-        35,
-        8,
-        168
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./benches/histogram_benchmark.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/simd/kernels.rs": {
-      "content_hash": [
-        230,
-        148,
-        70,
-        84,
-        37,
-        245,
-        185,
-        236,
-        157,
-        78,
-        150,
-        108,
-        42,
-        113,
-        96,
-        69,
-        196,
-        83,
-        13,
-        241,
-        221,
-        220,
-        113,
-        176,
-        48,
-        137,
-        57,
-        193,
-        67,
-        51,
-        180,
-        181
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.034733,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 76.03473,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/simd/kernels.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.965268,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 19.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 65"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 85"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 64 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/process_extra.rs": {
-      "content_hash": [
-        249,
-        194,
-        210,
-        58,
-        37,
-        142,
-        229,
-        146,
-        33,
-        10,
-        124,
-        9,
-        68,
-        61,
-        230,
-        166,
-        39,
-        224,
-        179,
-        67,
-        186,
-        7,
-        60,
-        209,
-        146,
-        156,
-        203,
-        160,
-        83,
-        113,
-        0,
-        120
-      ],
-      "score": {
-        "structural_complexity": 15.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.468172,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.46817,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/process_extra.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5318277,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 17.7%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 63"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 43 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/widgets/gauge.rs": {
-      "content_hash": [
-        231,
-        113,
-        65,
-        201,
-        92,
-        234,
-        233,
-        44,
-        62,
-        116,
-        98,
-        82,
-        183,
-        202,
-        153,
-        6,
-        196,
-        13,
-        74,
-        240,
-        7,
-        175,
-        45,
-        4,
-        71,
-        20,
-        0,
-        106,
-        30,
-        6,
-        198,
-        74
-      ],
-      "score": {
-        "structural_complexity": 18.4,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.659039,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.05904,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/widgets/gauge.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 34 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 6.6000004,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 37"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.340961,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/app/tests.rs": {
-      "content_hash": [
-        55,
-        172,
-        102,
-        180,
-        113,
-        97,
-        152,
-        191,
-        42,
-        144,
-        161,
-        156,
-        64,
-        244,
-        188,
-        40,
-        215,
-        96,
-        177,
-        44,
-        75,
-        164,
-        200,
-        57,
-        199,
-        177,
-        132,
-        231,
-        128,
-        11,
-        46,
-        95
-      ],
-      "score": {
-        "structural_complexity": 19.3,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 14.655415,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.955414,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/app/tests.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.3445854,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 26.7%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 95 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 5.7000003,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 34"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/panels/disk.rs": {
-      "content_hash": [
-        160,
-        12,
-        245,
-        121,
-        71,
-        36,
-        83,
-        108,
-        187,
-        205,
-        124,
-        153,
-        160,
-        41,
-        176,
-        92,
-        70,
-        151,
-        128,
-        108,
-        196,
-        37,
-        83,
-        169,
-        74,
-        38,
-        65,
-        9,
-        215,
-        128,
-        101,
-        142
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/disk.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/types.rs": {
-      "content_hash": [
-        141,
-        247,
-        52,
-        104,
-        19,
-        38,
-        101,
-        167,
-        25,
-        68,
-        153,
-        203,
-        41,
-        24,
-        89,
-        65,
-        126,
-        224,
-        164,
-        2,
-        58,
-        230,
-        121,
-        51,
-        63,
-        110,
-        52,
-        213,
-        202,
-        82,
-        30,
-        229
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/types.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 12 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/theme.rs": {
-      "content_hash": [
-        39,
-        184,
-        153,
-        10,
-        41,
-        216,
-        28,
-        192,
-        117,
-        200,
-        134,
-        99,
-        108,
-        29,
-        11,
-        252,
-        48,
-        87,
-        195,
-        197,
-        220,
-        12,
-        194,
-        6,
-        96,
-        179,
-        71,
-        85,
-        226,
-        70,
-        229,
-        231
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/theme.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 12 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./wasm-pkg/src/lib.rs": {
-      "content_hash": [
-        164,
-        18,
-        104,
-        114,
-        136,
-        161,
-        71,
-        192,
-        222,
-        219,
-        40,
-        35,
-        80,
-        25,
-        30,
-        135,
-        136,
-        144,
-        149,
-        43,
-        30,
-        61,
-        68,
-        226,
-        137,
-        65,
-        194,
-        99,
-        136,
-        161,
-        18,
-        116
-      ],
-      "score": {
-        "structural_complexity": 22.3,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.188604,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 98.4886,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./wasm-pkg/src/lib.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 60 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.7,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 24"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.811395,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 19.1%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/searchindex.js": {
-      "content_hash": [
-        104,
-        215,
-        75,
-        187,
-        244,
-        102,
-        145,
-        120,
-        204,
-        10,
-        224,
-        211,
-        173,
-        103,
-        19,
-        45,
-        14,
-        88,
-        154,
-        150,
-        52,
-        26,
-        210,
-        185,
-        26,
-        47,
-        161,
-        237,
-        242,
-        75,
-        30,
-        21
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/searchindex.js",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/disk_entropy.rs": {
-      "content_hash": [
-        159,
-        106,
-        187,
-        238,
-        158,
-        83,
-        83,
-        160,
-        5,
-        250,
-        9,
-        85,
-        181,
-        155,
-        191,
-        46,
-        147,
-        15,
-        97,
-        184,
-        97,
-        123,
-        122,
-        53,
-        209,
-        108,
-        116,
-        234,
-        25,
-        253,
-        178,
-        197
-      ],
-      "score": {
-        "structural_complexity": 9.5,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.860214,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 86.360214,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/disk_entropy.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 4.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 39"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 76"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 47 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1397848,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 15.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/svg_output.rs": {
-      "content_hash": [
-        218,
-        224,
-        235,
-        173,
-        237,
-        34,
-        233,
-        52,
-        159,
-        98,
-        109,
-        86,
-        89,
-        77,
-        198,
-        34,
-        190,
-        151,
-        131,
-        12,
-        63,
-        15,
-        236,
-        18,
-        135,
-        1,
-        22,
-        20,
-        96,
-        230,
-        40,
-        87
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/svg_output.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/loss_training.rs": {
-      "content_hash": [
-        219,
-        153,
-        86,
-        192,
-        62,
-        25,
-        61,
-        169,
-        15,
-        227,
-        221,
-        102,
-        122,
-        43,
-        28,
-        157,
-        163,
-        33,
-        25,
-        18,
-        253,
-        229,
-        235,
-        50,
-        121,
-        231,
-        41,
-        229,
-        198,
-        118,
-        185,
-        1
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/loss_training.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/psi.rs": {
-      "content_hash": [
-        21,
-        14,
-        166,
-        47,
-        70,
-        36,
-        112,
-        251,
-        154,
-        210,
-        48,
-        164,
-        168,
-        127,
-        84,
-        130,
-        115,
-        213,
-        137,
-        178,
-        132,
-        239,
-        23,
-        45,
-        89,
-        189,
-        51,
-        62,
-        93,
-        171,
-        69,
-        246
-      ],
-      "score": {
-        "structural_complexity": 21.1,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 94.63636,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/psi.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.9,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 28"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/grammar/facet.rs": {
-      "content_hash": [
-        79,
-        185,
-        217,
-        244,
-        149,
-        170,
-        147,
-        33,
-        77,
-        162,
-        99,
-        217,
-        250,
-        3,
-        248,
-        193,
-        94,
-        162,
-        52,
-        149,
-        137,
-        5,
-        215,
-        43,
-        229,
-        202,
-        33,
-        123,
-        58,
-        75,
-        101,
-        163
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 6.5,
-        "total": 96.81818,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/grammar/facet.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 3.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 7 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/plots/loss_curve.rs": {
-      "content_hash": [
-        56,
-        209,
-        240,
-        26,
-        94,
-        114,
-        34,
-        137,
-        92,
-        84,
-        116,
-        172,
-        235,
-        125,
-        42,
-        10,
-        69,
-        220,
-        63,
-        169,
-        37,
-        207,
-        4,
-        174,
-        155,
-        34,
-        200,
-        225,
-        177,
-        9,
-        159,
-        217
-      ],
-      "score": {
-        "structural_complexity": 12.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.718147,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 88.71815,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/plots/loss_curve.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 38 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 54"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.2818532,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.4%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 7 levels"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/ffi/mod.rs": {
-      "content_hash": [
-        117,
-        73,
-        86,
-        108,
-        35,
-        80,
-        5,
-        87,
-        67,
-        1,
-        80,
-        97,
-        173,
-        38,
-        131,
-        243,
-        145,
-        214,
-        194,
-        189,
-        142,
-        60,
-        237,
-        63,
-        31,
-        24,
-        183,
-        168,
-        233,
-        17,
-        131,
-        134
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.5,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.5,
-        "total": 97.27273,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/ffi/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.5%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 0.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 1 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/theme-tomorrow_night.js": {
-      "content_hash": [
-        118,
-        179,
-        26,
-        36,
-        133,
-        52,
-        192,
-        172,
-        173,
-        242,
-        169,
-        253,
-        35,
-        120,
-        188,
-        122,
-        83,
-        111,
-        108,
-        254,
-        244,
-        57,
-        208,
-        171,
-        110,
-        22,
-        145,
-        132,
-        207,
-        209,
-        136,
-        24
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/theme-tomorrow_night.js",
-        "penalties_applied": [
-          {
-            "source_metric": "Consistency",
-            "amount": 10.0,
-            "applied_to": [
-              "Consistency"
-            ],
-            "issue": "Inconsistent semicolon usage detected"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/bin/trueno_monitor.rs": {
-      "content_hash": [
-        250,
-        9,
-        35,
-        244,
-        222,
-        78,
-        49,
-        93,
-        252,
-        65,
-        51,
-        17,
-        80,
-        186,
-        165,
-        93,
-        163,
-        48,
-        189,
-        112,
-        166,
-        124,
-        166,
-        200,
-        17,
-        165,
-        23,
-        61,
-        125,
-        190,
-        255,
-        219
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/bin/trueno_monitor.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/readme_demo.rs": {
-      "content_hash": [
-        107,
-        214,
-        188,
-        121,
-        144,
-        19,
-        65,
-        108,
-        67,
-        221,
-        132,
-        234,
-        143,
-        156,
-        167,
-        150,
-        33,
-        111,
-        86,
-        107,
-        31,
-        11,
-        81,
-        50,
-        219,
-        53,
-        24,
-        30,
-        70,
-        92,
-        83,
-        73
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/readme_demo.rs",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/interop/aprender.rs": {
-      "content_hash": [
-        184,
-        84,
-        61,
-        136,
-        54,
-        26,
-        66,
-        33,
-        186,
-        222,
-        47,
-        223,
-        97,
-        15,
-        166,
-        183,
-        76,
-        39,
-        202,
-        122,
-        139,
-        35,
-        67,
-        89,
-        28,
-        183,
-        29,
-        37,
-        87,
-        184,
-        85,
-        60
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.32558,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.11417,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/interop/aprender.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 47 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.6744187,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 18.4%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/bin/debug_disk.rs": {
-      "content_hash": [
-        40,
-        102,
-        146,
-        143,
-        141,
-        223,
-        204,
-        96,
-        172,
-        158,
-        119,
-        190,
-        39,
-        95,
-        241,
-        166,
-        96,
-        109,
-        196,
-        204,
-        58,
-        158,
-        218,
-        85,
-        155,
-        150,
-        79,
-        127,
-        41,
-        245,
-        135,
-        218
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.0,
-        "total": 98.18182,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/bin/debug_disk.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 4 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/btop.rs": {
-      "content_hash": [
-        185,
-        228,
-        204,
-        79,
-        140,
-        96,
-        176,
-        198,
-        57,
-        47,
-        142,
-        195,
-        71,
-        38,
-        145,
-        35,
-        122,
-        249,
-        255,
-        149,
-        113,
-        73,
-        133,
-        88,
-        196,
-        26,
-        8,
-        169,
-        135,
-        60,
-        47,
-        56
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.890995,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 77.89099,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/btop.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.1090047,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.5%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 135"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 125"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 53 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/app/mod.rs": {
-      "content_hash": [
-        76,
-        140,
-        179,
-        207,
-        215,
-        223,
-        246,
-        254,
-        239,
-        128,
-        7,
-        175,
-        155,
-        159,
-        126,
-        155,
-        77,
-        42,
-        44,
-        66,
-        7,
-        233,
-        244,
-        188,
-        121,
-        87,
-        181,
-        163,
-        104,
-        21,
-        238,
-        55
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.848791,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 77.84879,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/app/mod.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.1512082,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 185"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 93 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 174"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/gpu_simd.rs": {
-      "content_hash": [
-        250,
-        39,
-        183,
-        25,
-        165,
-        247,
-        251,
-        105,
-        96,
-        85,
-        209,
-        165,
-        111,
-        154,
-        4,
-        211,
-        121,
-        144,
-        19,
-        181,
-        242,
-        216,
-        33,
-        243,
-        213,
-        128,
-        34,
-        107,
-        151,
-        93,
-        91,
-        135
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.594936,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 93.26813,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/gpu_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.4050634,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 12.0%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 19 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/panels/network.rs": {
-      "content_hash": [
-        254,
-        10,
-        35,
-        134,
-        66,
-        124,
-        195,
-        140,
-        46,
-        18,
-        90,
-        206,
-        65,
-        44,
-        92,
-        176,
-        222,
-        202,
-        168,
-        85,
-        126,
-        75,
-        236,
-        66,
-        90,
-        136,
-        248,
-        240,
-        77,
-        151,
-        28,
-        183
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 8.5,
-        "total": 98.63637,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/panels/network.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.5,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 3 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/falsification_tests.rs": {
-      "content_hash": [
-        122,
-        74,
-        21,
-        195,
-        7,
-        39,
-        68,
-        5,
-        144,
-        84,
-        108,
-        222,
-        2,
-        182,
-        125,
-        128,
-        46,
-        39,
-        148,
-        203,
-        31,
-        88,
-        106,
-        101,
-        103,
-        125,
-        245,
-        224,
-        31,
-        106,
-        72,
-        67
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/falsification_tests.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 24 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/memory.rs": {
-      "content_hash": [
-        101,
-        13,
-        253,
-        170,
-        165,
-        215,
-        250,
-        206,
-        33,
-        143,
-        185,
-        146,
-        41,
-        22,
-        164,
-        112,
-        155,
-        2,
-        48,
-        217,
-        186,
-        159,
-        235,
-        241,
-        245,
-        98,
-        233,
-        8,
-        71,
-        252,
-        50,
-        204
-      ],
-      "score": {
-        "structural_complexity": 10.599999,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.806084,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 87.40608,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/memory.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 42 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.1939163,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.0%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.900001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 48"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 35"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/analyzers/treemap.rs": {
-      "content_hash": [
-        98,
-        95,
-        190,
-        170,
-        248,
-        112,
-        229,
-        54,
-        176,
-        16,
-        149,
-        200,
-        132,
-        228,
-        119,
-        202,
-        183,
-        183,
-        59,
-        68,
-        139,
-        4,
-        46,
-        137,
-        86,
-        168,
-        188,
-        53,
-        86,
-        141,
-        156,
-        107
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 16.67426,
-        "coupling_score": 14.2,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 75.87426,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/analyzers/treemap.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 106"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 3.3257403,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 16.6%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 77"
-          },
-          {
-            "source_metric": "Coupling",
-            "amount": 0.8,
-            "applied_to": [
-              "Coupling"
-            ],
-            "issue": "Too many imports: 24"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 89 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/interop/entrenar.rs": {
-      "content_hash": [
-        198,
-        0,
-        61,
-        125,
-        60,
-        89,
-        162,
-        89,
-        70,
-        52,
-        241,
-        206,
-        187,
-        244,
-        235,
-        239,
-        111,
-        110,
-        254,
-        111,
-        18,
-        182,
-        186,
-        123,
-        60,
-        127,
-        35,
-        192,
-        42,
-        201,
-        23,
-        34
-      ],
-      "score": {
-        "structural_complexity": 12.2,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.035929,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 89.23593,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/interop/entrenar.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 63 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.964072,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 37"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 9.3,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 46"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/subprocess.rs": {
-      "content_hash": [
-        234,
-        132,
-        7,
-        193,
-        60,
-        7,
-        156,
-        159,
-        149,
-        96,
-        235,
-        68,
-        123,
-        15,
-        239,
-        36,
-        125,
-        34,
-        8,
-        245,
-        230,
-        65,
-        44,
-        113,
-        194,
-        65,
-        122,
-        219,
-        47,
-        206,
-        175,
-        218
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 95.454544,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/subprocess.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 10 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./src/monitor/collectors/process_simd.rs": {
-      "content_hash": [
-        72,
-        159,
-        64,
-        25,
-        53,
-        171,
-        139,
-        20,
-        84,
-        161,
-        26,
-        187,
-        158,
-        129,
-        70,
-        170,
-        240,
-        253,
-        241,
-        167,
-        239,
-        228,
-        68,
-        220,
-        42,
-        44,
-        195,
-        146,
-        155,
-        47,
-        218,
-        81
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.068274,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 92.78934,
-        "grade": "A",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./src/monitor/collectors/process_simd.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 2.931727,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.7%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 42 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./book/book/elasticlunr.min.js": {
-      "content_hash": [
-        193,
-        164,
-        130,
-        94,
-        39,
-        184,
-        85,
-        217,
-        70,
-        25,
-        49,
-        125,
-        50,
-        141,
-        144,
-        181,
-        182,
-        168,
-        106,
-        133,
-        86,
-        71,
-        117,
-        123,
-        77,
-        243,
-        118,
-        189,
-        56,
-        86,
-        110,
-        105
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 10.0,
-        "total": 100.0,
-        "grade": "APLus",
-        "confidence": 0.9,
-        "language": "JavaScript",
-        "file_path": "./book/book/elasticlunr.min.js",
-        "penalties_applied": [],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./examples/aprender_integration.rs": {
-      "content_hash": [
-        56,
-        236,
-        216,
-        1,
-        31,
-        250,
-        141,
-        239,
-        58,
-        205,
-        103,
-        245,
-        66,
-        255,
-        58,
-        145,
-        32,
-        41,
-        128,
-        38,
-        176,
-        248,
-        95,
-        224,
-        247,
-        26,
-        119,
-        6,
-        108,
-        142,
-        97,
-        229
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./examples/aprender_integration.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/src/panels/disk_network.rs": {
-      "content_hash": [
-        104,
-        147,
-        28,
-        79,
-        160,
-        12,
-        108,
-        28,
-        115,
-        30,
-        66,
-        69,
-        255,
-        252,
-        10,
-        205,
-        109,
-        113,
-        136,
-        222,
-        136,
-        131,
-        15,
-        253,
-        127,
-        107,
-        95,
-        197,
-        4,
-        173,
-        75,
-        173
-      ],
-      "score": {
-        "structural_complexity": 0.0,
-        "semantic_complexity": 19.0,
-        "duplication_ratio": 17.663422,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 76.66342,
-        "grade": "B",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/src/panels/disk_network.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 176"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 128"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 51 duplicate code patterns"
-          },
-          {
-            "source_metric": "SemanticComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "SemanticComplexity"
-            ],
-            "issue": "Too many parameters: 7"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.3365786,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 11.7%"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/tests/playbook_test.rs": {
-      "content_hash": [
-        148,
-        4,
-        197,
-        95,
-        177,
-        172,
-        127,
-        28,
-        173,
-        243,
-        200,
-        164,
-        58,
-        100,
-        235,
-        119,
-        85,
-        133,
-        20,
-        14,
-        101,
-        206,
-        18,
-        29,
-        195,
-        35,
-        200,
-        224,
-        224,
-        219,
-        57,
-        29
-      ],
-      "score": {
-        "structural_complexity": 11.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 17.99591,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 88.99591,
-        "grade": "AMinus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/tests/playbook_test.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 72"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 4.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 38"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.0040898,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 10.0%"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 5.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 43 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
-    },
-    "./crates/ttop/examples/presentar_demo.rs": {
-      "content_hash": [
-        228,
-        113,
-        165,
-        214,
-        17,
-        157,
-        3,
-        125,
-        24,
-        242,
-        166,
-        87,
-        25,
-        207,
-        204,
-        78,
-        92,
-        40,
-        205,
-        102,
-        62,
-        221,
-        27,
-        154,
-        144,
-        127,
-        170,
-        74,
-        101,
-        166,
-        223,
-        72
-      ],
-      "score": {
-        "structural_complexity": 25.0,
-        "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
-        "coupling_score": 15.0,
-        "doc_coverage": 10.0,
-        "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APLus",
-        "confidence": 1.0,
-        "language": "Rust",
-        "file_path": "./crates/ttop/examples/presentar_demo.rs",
-        "penalties_applied": [
-          {
-            "source_metric": "Duplication",
-            "amount": 1.0,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Found 2 duplicate code patterns"
-          }
-        ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false
-      },
-      "components": {
-        "complexity_breakdown": {},
-        "duplication_sources": [],
-        "coupling_dependencies": [],
-        "doc_missing_items": [],
-        "consistency_violations": []
-      },
-      "git_context": null
     }
   },
   "summary": {
     "total_files": 201,
-    "avg_score": 94.233986,
+    "avg_score": 94.23551,
     "grade_distribution": {
-      "A": 55,
+      "BPlus": 3,
       "BMinus": 1,
-      "AMinus": 13,
-      "B": 14,
       "APLus": 115,
-      "BPlus": 3
+      "AMinus": 13,
+      "A": 55,
+      "B": 14
     },
     "languages": {
-      "JavaScript": 15,
       "Rust": 180,
+      "JavaScript": 15,
       "TypeScript": 6
     }
   }


### PR DESCRIPTION
## Summary
- Migrate Quality Gate job from `ubuntu-latest` to `[self-hosted, clean-room]`

Per repo-standards §2.1.1 — self-hosted primary for sovereignty.