### PR TITLE
ci: remove unified gate from ci.yml (badge fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-# CI — lint, test, coverage, security, and unified gate
+# CI — lint, test, coverage, security
+# Unified gate runs separately via org ruleset on PRs.
 name: CI
 
 on:
@@ -51,10 +52,3 @@ jobs:
           cargo install cargo-audit --locked || true
           cargo audit
         continue-on-error: true
-
-  unified:
-    uses: paiml/.github/.github/workflows/unified-gate.yml@main
-    with:
-      repo: ${{ github.event.repository.name }}
-      pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit


### PR DESCRIPTION
## Summary
- Remove the `unified:` job that calls the reusable unified-gate workflow
- Per-repo CI should only have test/lint/coverage/security/gate jobs
- The unified gate runs separately via org ruleset on PRs, not in the per-repo CI that produces the badge

## Why
The unified gate FAILS due to infrastructure issues, making the CI badge RED even though all per-repo jobs PASS.

## Test plan
- [ ] Verify CI badge turns GREEN after merge
- [ ] Verify org ruleset still enforces unified gate on PRs